### PR TITLE
Fix fetch of translation files not using base-href #31

### DIFF
--- a/src/app/transloco-loader.ts
+++ b/src/app/transloco-loader.ts
@@ -3,12 +3,14 @@ import {Translation, TranslocoLoader} from '@jsverse/transloco';
 import {HttpClient} from '@angular/common/http';
 import {Observable} from 'rxjs';
 import {type Language} from './shared/types/language.types';
+import {Location} from '@angular/common';
 
 @Injectable({providedIn: 'root'})
 export class TranslocoHttpLoader implements TranslocoLoader {
   private readonly http = inject(HttpClient);
+  private readonly location = inject(Location);
 
   public getTranslation(language: Language): Observable<Translation> {
-    return this.http.get<Translation>(`/i18n/${language}.json`);
+    return this.http.get<Translation>(this.location.prepareExternalUrl(`/i18n/${language}.json`));
   }
 }


### PR DESCRIPTION
The JSON files for the translation service are fetched using a HTTPClient. Angular cannot detect that this HTTPClient is doing a request to public assets and thus cannot prepend the base-href automatically. Angular does provide a function in the Location service to generate a URL that uses the base-href prefix which is used in this commit.