### PR TITLE
Fix auto-deploy workflow executed twice when a PR is merged #4

### DIFF
--- a/.github/workflows/auto-deploy.yml
+++ b/.github/workflows/auto-deploy.yml
@@ -4,11 +4,6 @@ on:
   push:
     branches:
       - main
-  pull_request:
-    branches:
-      - main
-    types:
-      - closed
 
 env:
   NODE_VERSION: '22'


### PR DESCRIPTION
The auto-deploy workflow is intended to automatically deploy the main branch to github-pages whenever a PR is merged or something is pushed to the main branch. However, merging a PR apparently also pushes to the main branch which causes the workflow to be triggered twice, once for closing the PR and once for pushing to the main branch. This means, however, that the trigger on closed PRs is redundant and can be removed.