### PR TITLE
Sort typescript imports #32

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -19,5 +19,10 @@
       }
     }
   ],
-  "endOfLine": "lf"
+  "endOfLine": "lf",
+  "plugins": ["@ianvs/prettier-plugin-sort-imports"],
+  "importOrder": ["<BUILTIN_MODULES>", "<THIRD_PARTY_MODULES>", "^[.]", "<TYPES>", "<TYPES>^[.]"],
+  "importOrderParserPlugins": ["typescript", "decorators-legacy"],
+  "importOrderTypeScriptVersion": "5.5.2",
+  "importOrderCaseSensitive": false
 }

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,9 +1,9 @@
 // @ts-check
-import {fixupPluginRules} from '@eslint/compat';
 import eslint from '@eslint/js';
 import ngrx from '@ngrx/eslint-plugin/v9/index.js';
 import angular from 'angular-eslint';
 import prettierRecommended from 'eslint-plugin-prettier/recommended';
+import tseslint from 'typescript-eslint';
 /**
  * TODO: The following imports should be revisited once the following issues are resolved:
  *  * eslint-plugin-rxjs-angular
@@ -14,9 +14,10 @@ import prettierRecommended from 'eslint-plugin-prettier/recommended';
  *    Either it will be updated to support ESLint 9 or included into 'rxjs'
  *    * https://github.com/ReactiveX/rxjs/discussions/7492
  */
+// prettier-ignore
+import {fixupPluginRules} from '@eslint/compat';
 import rxjsAngular from 'eslint-plugin-rxjs-angular';
 import rxjsX from 'eslint-plugin-rxjs-x';
-import tseslint from 'typescript-eslint';
 
 export default tseslint.config(
   {

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,9 +1,9 @@
 // @ts-check
+import {fixupPluginRules} from '@eslint/compat';
 import eslint from '@eslint/js';
-import tseslint from 'typescript-eslint';
+import ngrx from '@ngrx/eslint-plugin/v9/index.js';
 import angular from 'angular-eslint';
 import prettierRecommended from 'eslint-plugin-prettier/recommended';
-import ngrx from '@ngrx/eslint-plugin/v9/index.js';
 /**
  * TODO: The following imports should be revisited once the following issues are resolved:
  *  * eslint-plugin-rxjs-angular
@@ -15,8 +15,8 @@ import ngrx from '@ngrx/eslint-plugin/v9/index.js';
  *    * https://github.com/ReactiveX/rxjs/discussions/7492
  */
 import rxjsAngular from 'eslint-plugin-rxjs-angular';
-import {fixupPluginRules} from '@eslint/compat';
 import rxjsX from 'eslint-plugin-rxjs-x';
+import tseslint from 'typescript-eslint';
 
 export default tseslint.config(
   {

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
         "@angular/compiler-cli": "^18.2.0",
         "@eslint/compat": "^1.2.4",
         "@eslint/js": "^9.16.0",
+        "@ianvs/prettier-plugin-sort-imports": "^4.4.1",
         "@jsverse/transloco-keys-manager": "^6.0.0",
         "@ngrx/eslint-plugin": "^18.1.1",
         "@types/jasmine": "~5.1.0",
@@ -1159,12 +1160,13 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.26.2",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.26.2.tgz",
-      "integrity": "sha512-DWMCZH9WA4Maitz2q21SRKHo9QXZxkDsbNZoVD62gusNtNBBqDg9i7uOhASfTfIGNzW+O+r7+jAlM8dwphcJKQ==",
+      "version": "7.26.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.26.7.tgz",
+      "integrity": "sha512-kEvgGGgEjRUutvdVvZhbn/BxVt+5VSpwXz1j3WYXQbXDo8KzFOPNG2GQbdAiNq8g6wn1yKk7C/qrke03a84V+w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.26.0"
+        "@babel/types": "^7.26.7"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -2537,10 +2539,11 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.26.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.0.tgz",
-      "integrity": "sha512-Z/yiTPj+lDVnF7lWeKCIJzaIkI0vYO87dMpZ4bg4TDrFe4XXLFWL1TbXU27gBP3QccxV9mZICCrnjnYlJjXHOA==",
+      "version": "7.26.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.7.tgz",
+      "integrity": "sha512-t8kDRGrKXyp6+tjUh7hw2RLyclsW4TRoRvRHtSyAX9Bb5ldlFh+90YAYY6awRXrlB4G5G2izNeGySpATlFzmOg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/helper-string-parser": "^7.25.9",
         "@babel/helper-validator-identifier": "^7.25.9"
@@ -3183,6 +3186,59 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@ianvs/prettier-plugin-sort-imports": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/@ianvs/prettier-plugin-sort-imports/-/prettier-plugin-sort-imports-4.4.1.tgz",
+      "integrity": "sha512-F0/Hrcfpy8WuxlQyAWJTEren/uxKhYonOGY4OyWmwRdeTvkh9mMSCxowZLjNkhwi/2ipqCgtXwwOk7tW0mWXkA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@babel/generator": "^7.26.2",
+        "@babel/parser": "^7.26.2",
+        "@babel/traverse": "^7.25.9",
+        "@babel/types": "^7.26.0",
+        "semver": "^7.5.2"
+      },
+      "peerDependencies": {
+        "@vue/compiler-sfc": "2.7.x || 3.x",
+        "prettier": "2 || 3"
+      },
+      "peerDependenciesMeta": {
+        "@vue/compiler-sfc": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@ianvs/prettier-plugin-sort-imports/node_modules/@babel/generator": {
+      "version": "7.26.5",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.26.5.tgz",
+      "integrity": "sha512-2caSP6fN9I7HOe6nqhtft7V4g7/V/gfDsC3Ag4W7kEzzvRGKqiv0pu0HogPiZ3KaVSoNDhUws6IJjDjpfmYIXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.26.5",
+        "@babel/types": "^7.26.5",
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.25",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@ianvs/prettier-plugin-sort-imports/node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/@inquirer/checkbox": {

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "@angular/compiler-cli": "^18.2.0",
     "@eslint/compat": "^1.2.4",
     "@eslint/js": "^9.16.0",
+    "@ianvs/prettier-plugin-sort-imports": "^4.4.1",
     "@jsverse/transloco-keys-manager": "^6.0.0",
     "@ngrx/eslint-plugin": "^18.1.1",
     "@types/jasmine": "~5.1.0",

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -1,8 +1,8 @@
 import {TestBed} from '@angular/core/testing';
-import {AppComponent} from './app.component';
 import {provideTransloco} from '@jsverse/transloco';
-import {languages} from './shared/models/language';
+import {AppComponent} from './app.component';
 import {languageConfig} from './shared/configs/language.config';
+import {languages} from './shared/models/language';
 
 describe('AppComponent', () => {
   beforeEach(async () => {

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -2,7 +2,7 @@ import {Component, inject} from '@angular/core';
 import {RouterOutlet} from '@angular/router';
 import {TranslocoModule, TranslocoService} from '@jsverse/transloco';
 import {ParameterService} from './stac/service/parameter.service';
-import {type Language} from './shared/models/language';
+import type {Language} from './shared/models/language';
 
 @Component({
   selector: 'app-root',

--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -1,16 +1,15 @@
-import {ApplicationConfig, ErrorHandler, provideZoneChangeDetection, isDevMode} from '@angular/core';
-import {provideRouter} from '@angular/router';
-
-import {routes} from './app.routes';
-import {provideStore} from '@ngrx/store';
-import {provideEffects} from '@ngrx/effects';
-import {effects, metaReducers, reducers} from './state';
-import {ErrorHandlerService} from './error-handling/error-handler.service';
 import {provideHttpClient} from '@angular/common/http';
-import {TranslocoHttpLoader} from './transloco-loader';
+import {ApplicationConfig, ErrorHandler, isDevMode, provideZoneChangeDetection} from '@angular/core';
+import {provideRouter} from '@angular/router';
 import {provideTransloco} from '@jsverse/transloco';
-import {languages} from './shared/models/language';
+import {provideEffects} from '@ngrx/effects';
+import {provideStore} from '@ngrx/store';
+import {routes} from './app.routes';
+import {ErrorHandlerService} from './error-handling/error-handler.service';
 import {languageConfig} from './shared/configs/language.config';
+import {languages} from './shared/models/language';
+import {effects, metaReducers, reducers} from './state';
+import {TranslocoHttpLoader} from './transloco-loader';
 
 export const appConfig: ApplicationConfig = {
   providers: [

--- a/src/app/error-handling/components/fatal-error/fatal-error.component.ts
+++ b/src/app/error-handling/components/fatal-error/fatal-error.component.ts
@@ -1,8 +1,8 @@
 import {Component, OnDestroy, OnInit} from '@angular/core';
-import {Subscription, tap} from 'rxjs';
 import {ActivatedRoute} from '@angular/router';
-import {routeParamConstants} from '../../../shared/constants/route-param.constants';
 import {provideTranslocoScope, TranslocoModule} from '@jsverse/transloco';
+import {Subscription, tap} from 'rxjs';
+import {routeParamConstants} from '../../../shared/constants/route-param.constants';
 
 @Component({
   selector: 'app-fatal-error',

--- a/src/app/error-handling/error-handler.service.spec.ts
+++ b/src/app/error-handling/error-handler.service.spec.ts
@@ -1,10 +1,11 @@
 import {TestBed} from '@angular/core/testing';
-import {FatalError, RecoverableError, SilentError} from '../shared/errors/base.error';
-import {ErrorHandlerService} from './error-handler.service';
 import {Router} from '@angular/router';
-import {Page} from '../shared/enums/page.enum';
 import {routeParamConstants} from '../shared/constants/route-param.constants';
+import {Page} from '../shared/enums/page.enum';
+import {FatalError, RecoverableError, SilentError} from '../shared/errors/base.error';
 import {AngularDevModeService} from '../shared/services/angular-dev-mode.service';
+import {ErrorHandlerService} from './error-handler.service';
+
 import Spy = jasmine.Spy;
 
 class TestSilentError extends SilentError {}

--- a/src/app/error-handling/error-handler.service.ts
+++ b/src/app/error-handling/error-handler.service.ts
@@ -1,8 +1,8 @@
 import {ErrorHandler, Injectable, NgZone} from '@angular/core';
 import {Router} from '@angular/router';
-import {OpendataExplorerRuntimeError, RecoverableError, SilentError} from '../shared/errors/base.error';
-import {Page} from '../shared/enums/page.enum';
 import {routeParamConstants} from '../shared/constants/route-param.constants';
+import {Page} from '../shared/enums/page.enum';
+import {OpendataExplorerRuntimeError, RecoverableError, SilentError} from '../shared/errors/base.error';
 import {AngularDevModeService} from '../shared/services/angular-dev-mode.service';
 
 @Injectable({

--- a/src/app/shared/configs/language.config.ts
+++ b/src/app/shared/configs/language.config.ts
@@ -1,4 +1,4 @@
-import {type LanguageConfig} from '../models/configs/language-config';
+import type {LanguageConfig} from '../models/configs/language-config';
 
 export const languageConfig = {
   defaultLanguage: 'de',

--- a/src/app/shared/configs/stac.config.ts
+++ b/src/app/shared/configs/stac.config.ts
@@ -1,4 +1,4 @@
-import {type StacClientConfig} from '../models/configs/stac-config';
+import type {StacClientConfig} from '../models/configs/stac-config';
 
 export const defaultStacClientConfig = {
   baseUrl: 'https://sys-data.int.bgdi.ch/api/stac/v1',

--- a/src/app/shared/models/configs/language-config.ts
+++ b/src/app/shared/models/configs/language-config.ts
@@ -1,4 +1,4 @@
-import {type Language} from '../language';
+import type {Language} from '../language';
 
 export interface LanguageConfig {
   defaultLanguage: Language;

--- a/src/app/shared/models/parameter.ts
+++ b/src/app/shared/models/parameter.ts
@@ -1,4 +1,4 @@
-import {type TranslatableString} from './translatable-string';
+import type {TranslatableString} from './translatable-string';
 
 export interface Parameter {
   id: string;

--- a/src/app/shared/models/translatable-string.ts
+++ b/src/app/shared/models/translatable-string.ts
@@ -1,3 +1,3 @@
-import {type Language} from './language';
+import type {Language} from './language';
 
 export type TranslatableString = Record<Language, string>;

--- a/src/app/shared/services/angular-dev-mode.service.spec.ts
+++ b/src/app/shared/services/angular-dev-mode.service.spec.ts
@@ -1,6 +1,5 @@
 import {isDevMode} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
-
 import {AngularDevModeService} from './angular-dev-mode.service';
 
 describe('AngularDevModeService', () => {

--- a/src/app/shared/services/translation.service.ts
+++ b/src/app/shared/services/translation.service.ts
@@ -1,7 +1,7 @@
 import {inject, Injectable} from '@angular/core';
 import {TranslocoService} from '@jsverse/transloco';
-import {type TranslatableString} from '../models/translatable-string';
-import {type Language} from '../models/language';
+import type {Language} from '../models/language';
+import type {TranslatableString} from '../models/translatable-string';
 
 @Injectable({
   providedIn: 'root',

--- a/src/app/stac/service/parameter.service.spec.ts
+++ b/src/app/stac/service/parameter.service.spec.ts
@@ -1,6 +1,6 @@
 import {TestBed} from '@angular/core/testing';
-import {CsvParameter, ParameterService} from './parameter.service';
 import {type Parameter} from '../../shared/models/parameter';
+import {CsvParameter, ParameterService} from './parameter.service';
 
 describe('ParameterService', () => {
   let service: ParameterService;

--- a/src/app/stac/service/parameter.service.ts
+++ b/src/app/stac/service/parameter.service.ts
@@ -1,6 +1,6 @@
 import {inject, Injectable} from '@angular/core';
 import {StacApiService} from './stac-api.service';
-import {type Parameter} from '../../shared/models/parameter';
+import type {Parameter} from '../../shared/models/parameter';
 
 export interface CsvParameter {
   parameterShortname: string;

--- a/src/app/stac/service/stac-api.service.ts
+++ b/src/app/stac/service/stac-api.service.ts
@@ -1,7 +1,7 @@
 import {Injectable} from '@angular/core';
 import papa from 'papaparse';
-import {StacApiClient} from '../generated/stac-api.generated';
 import {defaultStacClientConfig} from '../../shared/configs/stac.config';
+import {StacApiClient} from '../generated/stac-api.generated';
 
 @Injectable({
   providedIn: 'root',

--- a/src/app/transloco-loader.ts
+++ b/src/app/transloco-loader.ts
@@ -1,9 +1,9 @@
+import {Location} from '@angular/common';
+import {HttpClient} from '@angular/common/http';
 import {inject, Injectable} from '@angular/core';
 import {Translation, TranslocoLoader} from '@jsverse/transloco';
-import {HttpClient} from '@angular/common/http';
 import {Observable} from 'rxjs';
-import {Location} from '@angular/common';
-import {type Language} from './shared/models/language';
+import type {Language} from './shared/models/language';
 
 @Injectable({providedIn: 'root'})
 export class TranslocoHttpLoader implements TranslocoLoader {

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,5 @@
 import {bootstrapApplication} from '@angular/platform-browser';
-import {appConfig} from './app/app.config';
 import {AppComponent} from './app/app.component';
+import {appConfig} from './app/app.config';
 
 bootstrapApplication(AppComponent, appConfig).catch((err) => console.error(err));

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -6,10 +6,6 @@
     "outDir": "./out-tsc/app",
     "types": []
   },
-  "files": [
-    "src/main.ts"
-  ],
-  "include": [
-    "src/**/*.d.ts"
-  ]
+  "files": ["src/main.ts"],
+  "include": ["src/**/*.d.ts"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,10 +19,7 @@
     "importHelpers": true,
     "target": "ES2022",
     "module": "ES2022",
-    "lib": [
-      "ES2022",
-      "dom"
-    ]
+    "lib": ["ES2022", "dom"]
   },
   "angularCompilerOptions": {
     "enableI18nLegacyMessageIdFormat": false,

--- a/tsconfig.spec.json
+++ b/tsconfig.spec.json
@@ -4,12 +4,7 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "./out-tsc/spec",
-    "types": [
-      "jasmine"
-    ]
+    "types": ["jasmine"]
   },
-  "include": [
-    "src/**/*.spec.ts",
-    "src/**/*.d.ts"
-  ]
+  "include": ["src/**/*.spec.ts", "src/**/*.d.ts"]
 }


### PR DESCRIPTION
Sorting imports makes the code more consistent and it is easier to distinguish between library imports and local imports. This is especially useful if there are a lot of imports in a single file. The plugin is configured to distinguish between type and value imports and it will merge multiple imports form the same source.

To do this, this PR adds the prettier plugin package "@ianvs/prettier-plugin-sort-imports" and configures it accordingly.

Prettier is used rather than eslint to sort imports the order of imports is considered to have no influence on semantics of the code. Imports should not have side-effects. The plugin would consider side-effects imports and make sure not to change the semantics. However, in Angular these are not common anyway.