### PR TITLE
Put loaded parameters into ngrx store #47

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "@ngrx/effects": "^18.1.1",
         "@ngrx/operators": "^18.1.1",
         "@ngrx/store": "^18.1.1",
+        "@ngrx/store-devtools": "^18.1.1",
         "immer": "^10.1.1",
         "papaparse": "^5.5.1",
         "rxjs": "~7.8.0",
@@ -4477,6 +4478,20 @@
       },
       "peerDependencies": {
         "@angular/core": "^18.0.0",
+        "rxjs": "^6.5.3 || ^7.5.0"
+      }
+    },
+    "node_modules/@ngrx/store-devtools": {
+      "version": "18.1.1",
+      "resolved": "https://registry.npmjs.org/@ngrx/store-devtools/-/store-devtools-18.1.1.tgz",
+      "integrity": "sha512-tfn9Ms1q2bl7VDWwHyj7dUbwmGiiVzIpOKZs39rsms8tG8hbvsxoczyQAp2w5erVtoJb8ltIh1/birKkS7HmuQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@angular/core": "^18.0.0",
+        "@ngrx/store": "18.1.1",
         "rxjs": "^6.5.3 || ^7.5.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@ngrx/effects": "^18.1.1",
     "@ngrx/operators": "^18.1.1",
     "@ngrx/store": "^18.1.1",
+    "@ngrx/store-devtools": "^18.1.1",
     "immer": "^10.1.1",
     "papaparse": "^5.5.1",
     "rxjs": "~7.8.0",

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -1,5 +1,6 @@
 import {TestBed} from '@angular/core/testing';
 import {provideTransloco} from '@jsverse/transloco';
+import {provideMockStore} from '@ngrx/store/testing';
 import {AppComponent} from './app.component';
 import {languageConfig} from './shared/configs/language.config';
 import {languages} from './shared/models/language';
@@ -20,6 +21,7 @@ describe('AppComponent', () => {
             },
           },
         }),
+        provideMockStore(),
       ],
     }).compileComponents();
   });

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,7 +1,8 @@
 import {Component, inject} from '@angular/core';
 import {RouterOutlet} from '@angular/router';
 import {TranslocoModule, TranslocoService} from '@jsverse/transloco';
-import {ParameterService} from './stac/service/parameter.service';
+import {Store} from '@ngrx/store';
+import {parameterActions} from './state/parameters/actions/parameter.action';
 import type {Language} from './shared/models/language';
 
 @Component({
@@ -13,7 +14,7 @@ import type {Language} from './shared/models/language';
 })
 export class AppComponent {
   private readonly translocoService = inject(TranslocoService);
-  private readonly parameterService = inject(ParameterService);
+  private readonly store = inject(Store);
 
   public title = 'meteoschweiz-opendata-explorer';
 
@@ -25,10 +26,9 @@ export class AppComponent {
     throw new Error('Test');
   }
 
-  public async testCsv(): Promise<void> {
-    const paramsA1 = await this.parameterService.getParametersForCollection('ch.meteoschweiz.ogd-smn');
-    console.log(paramsA1);
-    const paramsA2 = await this.parameterService.getParametersForCollection('ch.meteoschweiz.ogd-smn-precip');
-    console.log(paramsA2);
+  public testCsv(): void {
+    this.store.dispatch(
+      parameterActions.loadParameterForCollections({collections: ['ch.meteoschweiz.ogd-smn', 'ch.meteoschweiz.ogd-smn-precip']}),
+    );
   }
 }

--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -4,6 +4,7 @@ import {provideRouter} from '@angular/router';
 import {provideTransloco} from '@jsverse/transloco';
 import {provideEffects} from '@ngrx/effects';
 import {provideStore} from '@ngrx/store';
+import {provideStoreDevtools} from '@ngrx/store-devtools';
 import {routes} from './app.routes';
 import {ErrorHandlerService} from './error-handling/error-handler.service';
 import {languageConfig} from './shared/configs/language.config';
@@ -16,6 +17,14 @@ export const appConfig: ApplicationConfig = {
     provideZoneChangeDetection({eventCoalescing: true}),
     provideRouter(routes),
     provideStore(reducers, {metaReducers}),
+    provideStoreDevtools({
+      maxAge: 25, // Retains last 25 states
+      logOnly: !isDevMode(), // Restrict extension to log-only mode
+      autoPause: true, // Pauses recording actions and state changes when the extension window is not open
+      trace: false, //  If set to true, will include stack trace for every dispatched action, so you can see it in trace tab jumping directly to that part of code
+      traceLimit: 75, // maximum stack trace frames to be stored (in case trace option was provided as true)
+      connectInZone: true, // If set to true, the connection is established within the Angular zone
+    }),
     provideEffects(effects),
     {provide: ErrorHandler, useClass: ErrorHandlerService},
     provideHttpClient(),

--- a/src/app/shared/models/loading-state.ts
+++ b/src/app/shared/models/loading-state.ts
@@ -1,0 +1,1 @@
+export type LoadingState = undefined | 'loading' | 'loaded' | 'error';

--- a/src/app/stac/service/parameter.service.spec.ts
+++ b/src/app/stac/service/parameter.service.spec.ts
@@ -1,7 +1,6 @@
 import {TestBed} from '@angular/core/testing';
 import {Store} from '@ngrx/store';
 import {provideMockStore} from '@ngrx/store/testing';
-import {parameterActions} from '../../state/parameters/actions/parameter.action';
 import {CsvParameter, ParameterService} from './parameter.service';
 import type {Parameter} from '../../shared/models/parameter';
 
@@ -76,8 +75,8 @@ describe('ParameterService', () => {
     spyOn(service, 'getParametersForCollection').and.returnValue(new Promise((resolve) => resolve([aParameter])));
     spyOn(store, 'dispatch');
 
-    await service.loadParameterForCollections(collections);
+    const parameters = await service.loadParameterForCollections(collections);
 
-    expect(store.dispatch).toHaveBeenCalledWith(parameterActions.setLoadedParameters({parameters: [aParameter, aParameter, aParameter]}));
+    expect(parameters).toEqual(jasmine.arrayWithExactContents([aParameter, aParameter, aParameter]));
   });
 });

--- a/src/app/stac/service/parameter.service.spec.ts
+++ b/src/app/stac/service/parameter.service.spec.ts
@@ -1,13 +1,20 @@
 import {TestBed} from '@angular/core/testing';
-import {type Parameter} from '../../shared/models/parameter';
+import {Store} from '@ngrx/store';
+import {provideMockStore} from '@ngrx/store/testing';
+import {parameterActions} from '../../state/parameters/actions/parameter.action';
 import {CsvParameter, ParameterService} from './parameter.service';
+import type {Parameter} from '../../shared/models/parameter';
 
 describe('ParameterService', () => {
   let service: ParameterService;
+  let store: Store;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({});
+    TestBed.configureTestingModule({
+      providers: [provideMockStore()],
+    });
     service = TestBed.inject(ParameterService);
+    store = TestBed.inject(Store);
   });
 
   it('should be created', () => {
@@ -47,5 +54,30 @@ describe('ParameterService', () => {
         it: 'vento',
       },
     } satisfies Parameter);
+  });
+
+  it('should get parameters for each collection and write data to store', async () => {
+    const collections = ['a', 'b', 'c'];
+    const aParameter: Parameter = {
+      id: 'test00',
+      description: {
+        de: 'Ein Text',
+        en: 'Some text',
+        fr: 'Some text but french',
+        it: 'Some text but Italian',
+      },
+      group: {
+        de: 'Wind',
+        en: 'wind',
+        fr: 'vent',
+        it: 'vento',
+      },
+    };
+    spyOn(service, 'getParametersForCollection').and.returnValue(new Promise((resolve) => resolve([aParameter])));
+    spyOn(store, 'dispatch');
+
+    await service.loadParameterForCollections(collections);
+
+    expect(store.dispatch).toHaveBeenCalledWith(parameterActions.setLoadedParameters({parameters: [aParameter, aParameter, aParameter]}));
   });
 });

--- a/src/app/stac/service/parameter.service.ts
+++ b/src/app/stac/service/parameter.service.ts
@@ -1,6 +1,4 @@
 import {inject, Injectable} from '@angular/core';
-import {Store} from '@ngrx/store';
-import {parameterActions} from '../../state/parameters/actions/parameter.action';
 import {StacApiService} from './stac-api.service';
 import type {Parameter} from '../../shared/models/parameter';
 
@@ -25,11 +23,10 @@ export interface CsvParameter {
 })
 export class ParameterService {
   private readonly stacApiService = inject(StacApiService);
-  private readonly store = inject(Store);
 
-  public async loadParameterForCollections(collections: string[]): Promise<void> {
+  public async loadParameterForCollections(collections: string[]): Promise<Parameter[]> {
     const parameters = await Promise.all(collections.map((collection) => this.getParametersForCollection(collection)));
-    this.store.dispatch(parameterActions.setLoadedParameters({parameters: parameters.flat()}));
+    return parameters.flat();
   }
 
   public async getParametersForCollection(collection: string): Promise<Parameter[]> {

--- a/src/app/stac/service/parameter.service.ts
+++ b/src/app/stac/service/parameter.service.ts
@@ -1,4 +1,6 @@
 import {inject, Injectable} from '@angular/core';
+import {Store} from '@ngrx/store';
+import {parameterActions} from '../../state/parameters/actions/parameter.action';
 import {StacApiService} from './stac-api.service';
 import type {Parameter} from '../../shared/models/parameter';
 
@@ -23,6 +25,12 @@ export interface CsvParameter {
 })
 export class ParameterService {
   private readonly stacApiService = inject(StacApiService);
+  private readonly store = inject(Store);
+
+  public async loadParameterForCollections(collections: string[]): Promise<void> {
+    const parameters = await Promise.all(collections.map((collection) => this.getParametersForCollection(collection)));
+    this.store.dispatch(parameterActions.setLoadedParameters({parameters: parameters.flat()}));
+  }
 
   public async getParametersForCollection(collection: string): Promise<Parameter[]> {
     const csvParameters: CsvParameter[] = await this.stacApiService.getCollectionMetaCsvFile<CsvParameter>(collection, 'parameters');

--- a/src/app/state/index.ts
+++ b/src/app/state/index.ts
@@ -1,8 +1,15 @@
+import {Type} from '@angular/core';
+import {FunctionalEffect} from '@ngrx/effects';
 import {ActionReducerMap, MetaReducer} from '@ngrx/store';
+import {loadCollectionParameters} from './parameters/effects/parameter.effects';
+import {parameterFeature, parameterFeatureKey} from './parameters/reducers/parameter.reducer';
+import {ParameterState} from './parameters/states/parameter.state';
 
-// This interface will be filled out later, then this eslint-disable line can be deleted
-// eslint-disable-next-line @typescript-eslint/no-empty-object-type
-export interface State {}
-export const reducers: ActionReducerMap<State> = {};
-export const effects = [];
+export interface State {
+  [parameterFeatureKey]: ParameterState;
+}
+export const reducers: ActionReducerMap<State> = {
+  [parameterFeatureKey]: parameterFeature.reducer,
+};
+export const effects: (Type<unknown> | Record<string, FunctionalEffect>)[] = [{loadCollectionParameters}];
 export const metaReducers: MetaReducer<State>[] = [];

--- a/src/app/state/parameters/actions/parameter.action.ts
+++ b/src/app/state/parameters/actions/parameter.action.ts
@@ -1,0 +1,10 @@
+import {createActionGroup, props} from '@ngrx/store';
+import {Parameter} from '../../../shared/models/parameter';
+
+export const parameterActions = createActionGroup({
+  source: 'Parameters',
+  events: {
+    'Set loaded parameters': props<{parameters: Parameter[]}>(),
+    'Load parameter for collections': props<{collections: string[]}>(),
+  },
+});

--- a/src/app/state/parameters/actions/parameter.action.ts
+++ b/src/app/state/parameters/actions/parameter.action.ts
@@ -1,10 +1,12 @@
 import {createActionGroup, props} from '@ngrx/store';
 import {Parameter} from '../../../shared/models/parameter';
+import {errorProps} from '../../utils/error-props.util';
 
 export const parameterActions = createActionGroup({
   source: 'Parameters',
   events: {
     'Set loaded parameters': props<{parameters: Parameter[]}>(),
     'Load parameter for collections': props<{collections: string[]}>(),
+    'Set parameter loading error': errorProps(),
   },
 });

--- a/src/app/state/parameters/effects/parameter.effects.spec.ts
+++ b/src/app/state/parameters/effects/parameter.effects.spec.ts
@@ -25,15 +25,13 @@ describe('ParameterEffects', () => {
     store.resetSelectors();
   });
 
-  it('should call the parameter service to load collections', () => {
-    spyOn(parameterService, 'loadParameterForCollections');
+  it('should dispatch the SetParameter action when loading parameters for collections', () => {
+    spyOn(parameterService, 'loadParameterForCollections').and.resolveTo([]);
     actions$ = of(parameterActions.loadParameterForCollections({collections: ['collection']}));
 
-    loadCollectionParameters(actions$, store, parameterService).subscribe({
-      complete: () => {
-        expect(parameterService.loadParameterForCollections).toHaveBeenCalled();
-      },
-    });
+    loadCollectionParameters(actions$, store, parameterService).subscribe((action) =>
+      expect(action).toEqual(parameterActions.setLoadedParameters({parameters: []})),
+    );
   });
 
   it('should not call the service if the data is already loaded', () => {

--- a/src/app/state/parameters/effects/parameter.effects.spec.ts
+++ b/src/app/state/parameters/effects/parameter.effects.spec.ts
@@ -1,0 +1,50 @@
+import {TestBed} from '@angular/core/testing';
+import {Action} from '@ngrx/store';
+import {MockStore, provideMockStore} from '@ngrx/store/testing';
+import {Observable, of} from 'rxjs';
+import {ParameterService} from '../../../stac/service/parameter.service';
+import {parameterActions} from '../actions/parameter.action';
+import {parameterFeature} from '../reducers/parameter.reducer';
+import {loadCollectionParameters} from './parameter.effects';
+
+describe('ParameterEffects', () => {
+  let actions$: Observable<Action>;
+  let store: MockStore;
+  let parameterService: ParameterService;
+
+  beforeEach(() => {
+    actions$ = new Observable<Action>();
+    TestBed.configureTestingModule({
+      providers: [provideMockStore()],
+    });
+    store = TestBed.inject(MockStore);
+    parameterService = TestBed.inject(ParameterService);
+  });
+
+  afterEach(() => {
+    store.resetSelectors();
+  });
+
+  it('should call the parameter service to load collections', () => {
+    spyOn(parameterService, 'loadParameterForCollections');
+    actions$ = of(parameterActions.loadParameterForCollections({collections: ['collection']}));
+
+    loadCollectionParameters(actions$, store, parameterService).subscribe({
+      complete: () => {
+        expect(parameterService.loadParameterForCollections).toHaveBeenCalled();
+      },
+    });
+  });
+
+  it('should not call the service if the data is already loaded', () => {
+    spyOn(parameterService, 'loadParameterForCollections');
+    store.overrideSelector(parameterFeature.selectLoadingState, 'loaded');
+    actions$ = of(parameterActions.loadParameterForCollections({collections: ['collection']}));
+
+    loadCollectionParameters(actions$, store, parameterService).subscribe({
+      complete: () => {
+        expect(parameterService.loadParameterForCollections).not.toHaveBeenCalled();
+      },
+    });
+  });
+});

--- a/src/app/state/parameters/effects/parameter.effects.ts
+++ b/src/app/state/parameters/effects/parameter.effects.ts
@@ -1,0 +1,20 @@
+import {inject} from '@angular/core';
+import {Actions, createEffect, ofType} from '@ngrx/effects';
+import {concatLatestFrom} from '@ngrx/operators';
+import {Store} from '@ngrx/store';
+import {filter, tap} from 'rxjs';
+import {ParameterService} from '../../../stac/service/parameter.service';
+import {parameterActions} from '../actions/parameter.action';
+import {parameterFeature} from '../reducers/parameter.reducer';
+
+export const loadCollectionParameters = createEffect(
+  (actions$ = inject(Actions), store = inject(Store), parameterService = inject(ParameterService)) => {
+    return actions$.pipe(
+      ofType(parameterActions.loadParameterForCollections),
+      concatLatestFrom(() => store.select(parameterFeature.selectLoadingState)),
+      filter(([_, loadingState]) => loadingState !== 'loaded'),
+      tap(([{collections}]) => parameterService.loadParameterForCollections(collections)),
+    );
+  },
+  {functional: true, dispatch: false},
+);

--- a/src/app/state/parameters/reducers/parameter.reducer.ts
+++ b/src/app/state/parameters/reducers/parameter.reducer.ts
@@ -1,0 +1,32 @@
+import {createFeature, createReducer, on} from '@ngrx/store';
+import {parameterActions} from '../actions/parameter.action';
+import {ParameterState} from '../states/parameter.state';
+
+export const parameterFeatureKey = 'parameters';
+
+export const initialState: ParameterState = {
+  parameters: [],
+  loadingState: undefined,
+};
+
+export const parameterFeature = createFeature({
+  name: parameterFeatureKey,
+  reducer: createReducer(
+    initialState,
+    on(
+      parameterActions.loadParameterForCollections,
+      (state): ParameterState => ({
+        ...state,
+        loadingState: state.loadingState !== 'loaded' ? 'loading' : state.loadingState,
+      }),
+    ),
+    on(
+      parameterActions.setLoadedParameters,
+      (state, {parameters}): ParameterState => ({
+        ...state,
+        parameters,
+        loadingState: 'loaded',
+      }),
+    ),
+  ),
+});

--- a/src/app/state/parameters/reducers/parameter.reducer.ts
+++ b/src/app/state/parameters/reducers/parameter.reducer.ts
@@ -28,5 +28,8 @@ export const parameterFeature = createFeature({
         loadingState: 'loaded',
       }),
     ),
+    on(parameterActions.setParameterLoadingError, (state): ParameterState => {
+      return {...state, loadingState: 'error'};
+    }),
   ),
 });

--- a/src/app/state/parameters/states/parameter.state.ts
+++ b/src/app/state/parameters/states/parameter.state.ts
@@ -1,6 +1,7 @@
+import {LoadingState} from '../../../shared/models/loading-state';
 import {Parameter} from '../../../shared/models/parameter';
 
 export interface ParameterState {
   parameters: Parameter[];
-  loadingState: undefined | 'loading' | 'loaded';
+  loadingState: LoadingState;
 }

--- a/src/app/state/parameters/states/parameter.state.ts
+++ b/src/app/state/parameters/states/parameter.state.ts
@@ -1,0 +1,6 @@
+import {Parameter} from '../../../shared/models/parameter';
+
+export interface ParameterState {
+  parameters: Parameter[];
+  loadingState: undefined | 'loading' | 'loaded';
+}


### PR DESCRIPTION
Parameters are loaded asynchronously for multiple collections and once loaded put into the store for the rest of the application to access it. The design is kept simple for now, so that a single error for one collection will be interpreted as a error for the whole process. This can be handled more granular later.

In order to facilitate debugging the store the package @ngrx/store-devtools has been added. This allows the browser-extension "Redux Dev Tools" to see events on the store and show how actions affect the store.