### PR TITLE
Handle parameter load error #47

### DIFF
--- a/public/i18n/de.json
+++ b/public/i18n/de.json
@@ -1,5 +1,6 @@
 {
   "greeting": "Hallo, {{ title }}!",
   "congraz": "Glückwunsch! Deine App funktioniert. 🎉",
-  "errorTest": "Fehler Test"
+  "errorTest": "Fehler Test",
+  "parameter.load.error": "Fehler beim Laden der Parameter"
 }

--- a/public/i18n/en.json
+++ b/public/i18n/en.json
@@ -2,5 +2,5 @@
   "greeting": "Hello, {{ title }}",
   "congraz": "Congratulations! Your app is running. 🎉",
   "errorTest": "Test Error",
-  "parameter.load.error": "Error loading the parameters"
+  "parameter.load.error": "Error loading parameters"
 }

--- a/public/i18n/en.json
+++ b/public/i18n/en.json
@@ -1,5 +1,6 @@
 {
   "greeting": "Hello, {{ title }}",
   "congraz": "Congratulations! Your app is running. 🎉",
-  "errorTest": "Test Error"
+  "errorTest": "Test Error",
+  "parameter.load.error": "Error loading the parameters"
 }

--- a/public/i18n/fr.json
+++ b/public/i18n/fr.json
@@ -1,5 +1,6 @@
 {
   "greeting": "Missing value for 'greeting'",
   "congraz": "Missing value for 'congraz'",
-  "errorTest": "Missing value for 'Test Error'"
+  "errorTest": "Missing value for 'Test Error'",
+  "parameter.load.error": "Erreur lors du chargement des paramètres"
 }

--- a/public/i18n/it.json
+++ b/public/i18n/it.json
@@ -1,5 +1,6 @@
 {
   "greeting": "Missing value for 'greeting'",
   "congraz": "Missing value for 'congraz'",
-  "errorTest": "Missing value for 'Test Error'"
+  "errorTest": "Missing value for 'Test Error'",
+  "parameter.load.error": "Errore durante il caricamento dei parametri"
 }

--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -3,7 +3,7 @@ import {ApplicationConfig, ErrorHandler, isDevMode, provideZoneChangeDetection} 
 import {provideAnimationsAsync} from '@angular/platform-browser/animations/async';
 import {provideRouter} from '@angular/router';
 import {provideTransloco} from '@jsverse/transloco';
-import {provideEffects} from '@ngrx/effects';
+import {EFFECTS_ERROR_HANDLER, provideEffects} from '@ngrx/effects';
 import {provideStore} from '@ngrx/store';
 import {provideStoreDevtools} from '@ngrx/store-devtools';
 import {routes} from './app.routes';
@@ -11,6 +11,7 @@ import {ErrorHandlerService} from './error-handling/error-handler.service';
 import {languageConfig} from './shared/configs/language.config';
 import {languages} from './shared/models/language';
 import {effects, metaReducers, reducers} from './state';
+import {effectErrorHandler} from './state/effects-error-handler.effects';
 import {TranslocoHttpLoader} from './transloco-loader';
 
 export const appConfig: ApplicationConfig = {
@@ -39,5 +40,9 @@ export const appConfig: ApplicationConfig = {
       loader: TranslocoHttpLoader,
     }),
     provideAnimationsAsync(),
+    {
+      provide: EFFECTS_ERROR_HANDLER,
+      useValue: effectErrorHandler,
+    },
   ],
 };

--- a/src/app/error-handling/error-handler.service.spec.ts
+++ b/src/app/error-handling/error-handler.service.spec.ts
@@ -1,5 +1,6 @@
 import {TestBed} from '@angular/core/testing';
 import {Router} from '@angular/router';
+import {TranslocoService} from '@jsverse/transloco';
 import {routeParamConstants} from '../shared/constants/route-param.constants';
 import {Page} from '../shared/enums/page.enum';
 import {FatalError, RecoverableError, SilentError} from '../shared/errors/base.error';
@@ -31,7 +32,10 @@ describe('ErrorHandlerService', () => {
   beforeEach(() => {
     const routerSpyObj = jasmine.createSpyObj<Router>(['navigate']);
     TestBed.configureTestingModule({
-      providers: [{provide: Router, useValue: routerSpyObj}],
+      providers: [
+        {provide: Router, useValue: routerSpyObj},
+        {provide: TranslocoService, useValue: {translate: (message: string) => message}},
+      ],
     });
     service = TestBed.inject(ErrorHandlerService);
     routerSpy = TestBed.inject(Router) as jasmine.SpyObj<Router>;

--- a/src/app/error-handling/error-handler.service.ts
+++ b/src/app/error-handling/error-handler.service.ts
@@ -1,5 +1,6 @@
 import {ErrorHandler, Injectable, NgZone} from '@angular/core';
 import {Router} from '@angular/router';
+import {TranslocoService} from '@jsverse/transloco';
 import {routeParamConstants} from '../shared/constants/route-param.constants';
 import {Page} from '../shared/enums/page.enum';
 import {OpendataExplorerRuntimeError, RecoverableError, SilentError} from '../shared/errors/base.error';
@@ -13,6 +14,7 @@ export class ErrorHandlerService implements ErrorHandler {
     private readonly router: Router,
     private readonly zone: NgZone,
     private readonly angularDevModeService: AngularDevModeService,
+    private readonly translocoService: TranslocoService,
   ) {}
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -26,12 +28,13 @@ export class ErrorHandlerService implements ErrorHandler {
       }
     }
 
+    const translatedMessage = this.translocoService.translate(error.message);
     if (error instanceof SilentError) {
       // these errors should only be logged to a frontend logging service, but not displayed.
     } else if (error instanceof RecoverableError) {
-      this.showRecoverableErrorMessage(error.message);
+      this.showRecoverableErrorMessage(translatedMessage);
     } else {
-      this.routeToErrorPage(error.message);
+      this.routeToErrorPage(translatedMessage);
     }
   }
 

--- a/src/app/shared/errors/parameter.error.ts
+++ b/src/app/shared/errors/parameter.error.ts
@@ -1,0 +1,5 @@
+import {FatalError} from './base.error';
+
+export class ParameterError extends FatalError {
+  public override message = 'parameter.load.error';
+}

--- a/src/app/shared/errors/parameter.error.ts
+++ b/src/app/shared/errors/parameter.error.ts
@@ -1,5 +1,6 @@
+import {marker} from '@jsverse/transloco-keys-manager/marker';
 import {FatalError} from './base.error';
 
 export class ParameterError extends FatalError {
-  public override message = 'parameter.load.error';
+  public override message = marker('parameter.load.error');
 }

--- a/src/app/state/effects-error-handler.effects.spec.ts
+++ b/src/app/state/effects-error-handler.effects.spec.ts
@@ -1,0 +1,46 @@
+import {ErrorHandler} from '@angular/core';
+import {fakeAsync, tick} from '@angular/core/testing';
+import {Action} from '@ngrx/store';
+import {Observable, of, throwError} from 'rxjs';
+import {effectErrorHandler} from './effects-error-handler.effects';
+
+describe('EffectsErrorHandler', () => {
+  let errorHandlerMock: jasmine.SpyObj<ErrorHandler>;
+
+  beforeEach(() => {
+    errorHandlerMock = jasmine.createSpyObj<ErrorHandler>(['handleError']);
+  });
+
+  describe('effectErrorHandler', () => {
+    it('catches an error and passes it to the global error handler', fakeAsync(() => {
+      const testError = new Error('Test error');
+      const observable$ = throwError(() => testError);
+      const result$ = effectErrorHandler(observable$, errorHandlerMock);
+
+      result$.subscribe({
+        error: () => {
+          fail('Error callback should not be called.');
+        },
+      });
+      tick();
+      expect(errorHandlerMock.handleError).toHaveBeenCalledWith(testError);
+    }));
+
+    it('does not call the error handler if the observable is running without error', (done: DoneFn) => {
+      const expectedAction: Action = {type: 'mockAction'};
+      const observable$: Observable<Action> = of(expectedAction);
+      const result$ = effectErrorHandler(observable$, errorHandlerMock);
+
+      result$.subscribe({
+        next: (action) => {
+          expect(action).toEqual(expectedAction);
+          expect(errorHandlerMock.handleError).not.toHaveBeenCalled();
+          done();
+        },
+        error: () => {
+          fail('Error callback should not be called for a successful observable');
+        },
+      });
+    });
+  });
+});

--- a/src/app/state/effects-error-handler.effects.ts
+++ b/src/app/state/effects-error-handler.effects.ts
@@ -1,0 +1,17 @@
+import {ErrorHandler} from '@angular/core';
+import {Action} from '@ngrx/store';
+import {catchError, Observable} from 'rxjs';
+
+// This effect is used to overwrite the default error handler from NGRX with our custom error handler.
+// This was done because the effects pipeline would die after ten errors within an effect.
+// Now, errors inside the effects can be handled like anywhere else in the application.
+// For more information see: https://ngrx.io/guide/effects/lifecycle#customizing-the-effects-error-handler
+export function effectErrorHandler<T extends Action>(observable$: Observable<T>, errorHandler: ErrorHandler): Observable<T> {
+  return observable$.pipe(
+    // eslint-disable-next-line rxjs-x/no-implicit-any-catch
+    catchError((error, caught) => {
+      errorHandler.handleError(error);
+      return caught;
+    }),
+  );
+}

--- a/src/app/state/effects-error-handler.effects.ts
+++ b/src/app/state/effects-error-handler.effects.ts
@@ -8,8 +8,7 @@ import {catchError, Observable} from 'rxjs';
 // For more information see: https://ngrx.io/guide/effects/lifecycle#customizing-the-effects-error-handler
 export function effectErrorHandler<T extends Action>(observable$: Observable<T>, errorHandler: ErrorHandler): Observable<T> {
   return observable$.pipe(
-    // eslint-disable-next-line rxjs-x/no-implicit-any-catch
-    catchError((error, caught) => {
+    catchError((error: unknown, caught) => {
       errorHandler.handleError(error);
       return caught;
     }),

--- a/src/app/state/index.ts
+++ b/src/app/state/index.ts
@@ -1,7 +1,7 @@
 import {Type} from '@angular/core';
 import {FunctionalEffect} from '@ngrx/effects';
 import {ActionReducerMap, MetaReducer} from '@ngrx/store';
-import {loadCollectionParameters} from './parameters/effects/parameter.effects';
+import {failLoadingCollectionParameters, loadCollectionParameters} from './parameters/effects/parameter.effects';
 import {parameterFeature, parameterFeatureKey} from './parameters/reducers/parameter.reducer';
 import {ParameterState} from './parameters/states/parameter.state';
 
@@ -11,5 +11,5 @@ export interface State {
 export const reducers: ActionReducerMap<State> = {
   [parameterFeatureKey]: parameterFeature.reducer,
 };
-export const effects: (Type<unknown> | Record<string, FunctionalEffect>)[] = [{loadCollectionParameters}];
+export const effects: (Type<unknown> | Record<string, FunctionalEffect>)[] = [{loadCollectionParameters, failLoadingCollectionParameters}];
 export const metaReducers: MetaReducer<State>[] = [];

--- a/src/app/state/parameters/effects/parameter.effects.spec.ts
+++ b/src/app/state/parameters/effects/parameter.effects.spec.ts
@@ -26,16 +26,17 @@ describe('ParameterEffects', () => {
     store.resetSelectors();
   });
 
-  it('should dispatch the SetParameter action when loading parameters for collections', () => {
+  it('should dispatch the SetParameter action when loading parameters for collections', (done) => {
     spyOn(parameterService, 'loadParameterForCollections').and.resolveTo([]);
     actions$ = of(parameterActions.loadParameterForCollections({collections: ['collection']}));
 
-    loadCollectionParameters(actions$, store, parameterService).subscribe((action) =>
-      expect(action).toEqual(parameterActions.setLoadedParameters({parameters: []})),
-    );
+    loadCollectionParameters(actions$, store, parameterService).subscribe((action) => {
+      expect(action).toEqual(parameterActions.setLoadedParameters({parameters: []}));
+      done();
+    });
   });
 
-  it('should not call the service if the data is already loaded', () => {
+  it('should not call the service if the data is already loaded', (done) => {
     spyOn(parameterService, 'loadParameterForCollections');
     store.overrideSelector(parameterFeature.selectLoadingState, 'loaded');
     actions$ = of(parameterActions.loadParameterForCollections({collections: ['collection']}));
@@ -43,6 +44,7 @@ describe('ParameterEffects', () => {
     loadCollectionParameters(actions$, store, parameterService).subscribe({
       complete: () => {
         expect(parameterService.loadParameterForCollections).not.toHaveBeenCalled();
+        done();
       },
     });
   });

--- a/src/app/state/parameters/effects/parameter.effects.spec.ts
+++ b/src/app/state/parameters/effects/parameter.effects.spec.ts
@@ -1,11 +1,12 @@
 import {TestBed} from '@angular/core/testing';
 import {Action} from '@ngrx/store';
 import {MockStore, provideMockStore} from '@ngrx/store/testing';
-import {Observable, of} from 'rxjs';
+import {catchError, EMPTY, Observable, of} from 'rxjs';
+import {ParameterError} from '../../../shared/errors/parameter.error';
 import {ParameterService} from '../../../stac/service/parameter.service';
 import {parameterActions} from '../actions/parameter.action';
 import {parameterFeature} from '../reducers/parameter.reducer';
-import {loadCollectionParameters} from './parameter.effects';
+import {failLoadingCollectionParameters, loadCollectionParameters} from './parameter.effects';
 
 describe('ParameterEffects', () => {
   let actions$: Observable<Action>;
@@ -44,5 +45,21 @@ describe('ParameterEffects', () => {
         expect(parameterService.loadParameterForCollections).not.toHaveBeenCalled();
       },
     });
+  });
+
+  it('should throw a Parameter error after dispatching setParameterLoadingError', (done: DoneFn) => {
+    const error = new Error('My cabbages!!!');
+    const expectedError = new ParameterError(error);
+
+    actions$ = of(parameterActions.setParameterLoadingError({error}));
+    failLoadingCollectionParameters(actions$)
+      .pipe(
+        catchError((caughtError: unknown) => {
+          expect(caughtError).toEqual(expectedError);
+          done();
+          return EMPTY;
+        }),
+      )
+      .subscribe();
   });
 });

--- a/src/app/state/parameters/reducers/parameter.reducer.spec.ts
+++ b/src/app/state/parameters/reducers/parameter.reducer.spec.ts
@@ -10,15 +10,6 @@ describe('Parameter Reducer', () => {
     state = initialState;
   });
 
-  describe('an unknown action', () => {
-    it('should return the previous state', () => {
-      const action = {} as never;
-      const result = parameterFeature.reducer(initialState, action);
-
-      expect(result).toBe(initialState);
-    });
-  });
-
   it('should set loadingState to loading when loadParameterForCollections is dispatched and loading state is currently not loaded', () => {
     state = {...state, loadingState: 'error'};
     const action = parameterActions.loadParameterForCollections({collections: ['test']});

--- a/src/app/state/parameters/reducers/parameter.reducer.spec.ts
+++ b/src/app/state/parameters/reducers/parameter.reducer.spec.ts
@@ -1,0 +1,61 @@
+import {Parameter} from '../../../shared/models/parameter';
+import {parameterActions} from '../actions/parameter.action';
+import {ParameterState} from '../states/parameter.state';
+import {initialState, parameterFeature} from './parameter.reducer';
+
+describe('Parameter Reducer', () => {
+  let state: ParameterState;
+
+  beforeEach(() => {
+    state = initialState;
+  });
+
+  describe('an unknown action', () => {
+    it('should return the previous state', () => {
+      const action = {} as never;
+      const result = parameterFeature.reducer(initialState, action);
+
+      expect(result).toBe(initialState);
+    });
+  });
+
+  it('should set loadingState to loading when loadParameterForCollections is dispatched and loading state is currently not loaded', () => {
+    state = {...state, loadingState: 'error'};
+    const action = parameterActions.loadParameterForCollections({collections: ['test']});
+    const result = parameterFeature.reducer(state, action);
+
+    expect(result.loadingState).toBe('loading');
+    expect(result.parameters).toEqual([]);
+  });
+
+  it('should not change loadingState if it is already loaded when loadParameterForCollections is dispatched', () => {
+    state = {...state, loadingState: 'loaded'};
+    const action = parameterActions.loadParameterForCollections({collections: ['test']});
+    const result = parameterFeature.reducer(state, action);
+
+    expect(result.loadingState).toBe('loaded');
+    expect(result.parameters).toEqual([]);
+  });
+
+  it('should set parameters and loadingState to loaded when setLoadedParameters is dispatched', () => {
+    const parameters: Parameter[] = [
+      {
+        id: 'test-parameter-id',
+        description: {de: 'test-description', en: 'test-description', fr: 'test-description', it: 'test-description'},
+        group: {de: 'test-group', en: 'test-group', fr: 'test-group', it: 'test-group'},
+      },
+    ];
+    const action = parameterActions.setLoadedParameters({parameters});
+    const result = parameterFeature.reducer(state, action);
+
+    expect(result.parameters).toEqual(parameters);
+    expect(result.loadingState).toBe('loaded');
+  });
+
+  it('should reset to initialState and set loadingState to error when setParameterLoadingError is dispatched', () => {
+    const action = parameterActions.setParameterLoadingError({});
+    const result = parameterFeature.reducer(state, action);
+
+    expect(result).toEqual({...initialState, loadingState: 'error'});
+  });
+});

--- a/src/app/state/parameters/reducers/parameter.reducer.ts
+++ b/src/app/state/parameters/reducers/parameter.reducer.ts
@@ -29,7 +29,7 @@ export const parameterFeature = createFeature({
       }),
     ),
     on(parameterActions.setParameterLoadingError, (state): ParameterState => {
-      return {...state, loadingState: 'error'};
+      return {...initialState, loadingState: 'error'};
     }),
   ),
 });


### PR DESCRIPTION
When the loading process for parameters fails it will show an error. A fatal error in this case as there is nothing else to show to the user. In order to handle @ngrx errors within their streams an effects-error-handler has been added..