### PR TITLE
Add station service #56

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -4,7 +4,7 @@ import {MatButtonToggle, MatButtonToggleGroup} from '@angular/material/button-to
 import {RouterOutlet} from '@angular/router';
 import {TranslocoModule, TranslocoService} from '@jsverse/transloco';
 import {Store} from '@ngrx/store';
-import {parameterActions} from './state/parameters/actions/parameter.action';
+import {collectionActions} from './state/collection/actions/collection.action';
 import type {Language} from './shared/models/language';
 
 @Component({
@@ -29,8 +29,6 @@ export class AppComponent {
   }
 
   public testCsv(): void {
-    this.store.dispatch(
-      parameterActions.loadParameterForCollections({collections: ['ch.meteoschweiz.ogd-smn', 'ch.meteoschweiz.ogd-smn-precip']}),
-    );
+    this.store.dispatch(collectionActions.loadCollections({collections: ['ch.meteoschweiz.ogd-smn', 'ch.meteoschweiz.ogd-smn-precip']}));
   }
 }

--- a/src/app/shared/models/station.ts
+++ b/src/app/shared/models/station.ts
@@ -1,0 +1,4 @@
+export interface Station {
+  id: string;
+  name: string;
+}

--- a/src/app/stac/models/csv-parameter.ts
+++ b/src/app/stac/models/csv-parameter.ts
@@ -1,0 +1,15 @@
+export interface CsvParameter {
+  parameterShortname: string;
+  parameterDescriptionDe: string;
+  parameterDescriptionFr: string;
+  parameterDescriptionIt: string;
+  parameterDescriptionEn: string;
+  parameterGroupDe: string;
+  parameterGroupFr: string;
+  parameterGroupIt: string;
+  parameterGroupEn: string;
+  parameterGranularity: 'T' | 'H' | 'D' | 'M' | 'Y';
+  parameterDecimals: `${number}`;
+  parameterDatatype: 'Integer' | 'Float';
+  parameterUnit: string;
+}

--- a/src/app/stac/models/csv-station.ts
+++ b/src/app/stac/models/csv-station.ts
@@ -1,0 +1,26 @@
+export interface CsvStation {
+  stationAbbr: string;
+  stationName: string;
+  stationCanton: string;
+  stationWigosId: string;
+  stationTypeDe: string;
+  stationTypeFr: string;
+  stationTypeIt: string;
+  stationTypeEn: string;
+  stationDataowner: string;
+  stationDataSince: string;
+  stationHeightMasl: string;
+  stationHeightBarometerMasl: string;
+  stationCoordinatesLv95East: `${number}`;
+  stationCoordinatesLv95North: `${number}`;
+  stationCoordinatesWgs84Lat: `${number}`;
+  stationCoordinatesWgs84Lon: `${number}`;
+  stationExpositionDe: string;
+  stationExpositionFr: string;
+  stationExpositionIt: string;
+  stationExpositionEn: string;
+  stationUrlDe: string;
+  stationUrlFr: string;
+  stationUrlIt: string;
+  stationUrlEn: string;
+}

--- a/src/app/stac/service/parameter.service.spec.ts
+++ b/src/app/stac/service/parameter.service.spec.ts
@@ -1,19 +1,16 @@
 import {TestBed} from '@angular/core/testing';
-import {Store} from '@ngrx/store';
 import {provideMockStore} from '@ngrx/store/testing';
 import {CsvParameter, ParameterService} from './parameter.service';
 import type {Parameter} from '../../shared/models/parameter';
 
 describe('ParameterService', () => {
   let service: ParameterService;
-  let store: Store;
 
   beforeEach(() => {
     TestBed.configureTestingModule({
       providers: [provideMockStore()],
     });
     service = TestBed.inject(ParameterService);
-    store = TestBed.inject(Store);
   });
 
   it('should be created', () => {
@@ -72,8 +69,7 @@ describe('ParameterService', () => {
         it: 'vento',
       },
     };
-    spyOn(service, 'getParametersForCollection').and.returnValue(new Promise((resolve) => resolve([aParameter])));
-    spyOn(store, 'dispatch');
+    spyOn(service, 'getParametersForCollection').and.resolveTo([aParameter]);
 
     const parameters = await service.loadParameterForCollections(collections);
 

--- a/src/app/stac/service/parameter.service.spec.ts
+++ b/src/app/stac/service/parameter.service.spec.ts
@@ -1,14 +1,58 @@
 import {TestBed} from '@angular/core/testing';
 import {provideMockStore} from '@ngrx/store/testing';
-import {CsvParameter, ParameterService} from './parameter.service';
+import {CsvParameter} from '../models/csv-parameter';
+import {ParameterService} from './parameter.service';
+import {StacApiService} from './stac-api.service';
 import type {Parameter} from '../../shared/models/parameter';
+
+const testCsvParameter: CsvParameter = {
+  parameterDatatype: 'Float',
+  parameterDecimals: '1',
+  parameterDescriptionDe: 'Ein Text',
+  parameterDescriptionEn: 'Some text',
+  parameterDescriptionFr: 'Some text but french',
+  parameterDescriptionIt: 'Some text but Italian',
+  parameterGranularity: 'D',
+  parameterGroupDe: 'Wind',
+  parameterGroupEn: 'wind',
+  parameterGroupFr: 'vent',
+  parameterGroupIt: 'vento',
+  parameterShortname: 'test00d0',
+  parameterUnit: 'm/s',
+};
+
+const testParameter: Parameter = {
+  // Last two characters define type of parameter and should thus not be part of id
+  id: 'test00',
+  description: {
+    de: 'Ein Text',
+    en: 'Some text',
+    fr: 'Some text but french',
+    it: 'Some text but Italian',
+  },
+  group: {
+    de: 'Wind',
+    en: 'wind',
+    fr: 'vent',
+    it: 'vento',
+  },
+};
 
 describe('ParameterService', () => {
   let service: ParameterService;
+  let stacApiService: jasmine.SpyObj<StacApiService>;
 
   beforeEach(() => {
+    stacApiService = jasmine.createSpyObj<StacApiService>('StacApiService', ['getCollectionMetaCsvFile']);
+
     TestBed.configureTestingModule({
-      providers: [provideMockStore()],
+      providers: [
+        provideMockStore(),
+        {
+          provide: StacApiService,
+          useValue: stacApiService,
+        },
+      ],
     });
     service = TestBed.inject(ParameterService);
   });
@@ -18,61 +62,19 @@ describe('ParameterService', () => {
   });
 
   it('should transform csvParameters to internal Type', () => {
-    const testValue: CsvParameter = {
-      parameterDatatype: 'Float',
-      parameterDecimals: '1',
-      parameterDescriptionDe: 'Ein Text',
-      parameterDescriptionEn: 'Some text',
-      parameterDescriptionFr: 'Some text but french',
-      parameterDescriptionIt: 'Some text but Italian',
-      parameterGranularity: 'D',
-      parameterGroupDe: 'Wind',
-      parameterGroupEn: 'wind',
-      parameterGroupFr: 'vent',
-      parameterGroupIt: 'vento',
-      parameterShortname: 'test00d0',
-      parameterUnit: 'm/s',
-    };
-    const result: Parameter = service.transformCsvParameter(testValue);
-    expect(result).toEqual({
-      // Last two characters define type of parameter and should thus not be part of id
-      id: 'test00',
-      description: {
-        de: 'Ein Text',
-        en: 'Some text',
-        fr: 'Some text but french',
-        it: 'Some text but Italian',
-      },
-      group: {
-        de: 'Wind',
-        en: 'wind',
-        fr: 'vent',
-        it: 'vento',
-      },
-    } satisfies Parameter);
+    // transformCsvParameter is private. To access it we need to use property access else TypeScript complains
+    // eslint-disable-next-line @typescript-eslint/dot-notation
+    const result: Parameter = service['transformCsvParameter'](testCsvParameter);
+    expect(result).toEqual(testParameter);
   });
 
   it('should get parameters for each collection and write data to store', async () => {
     const collections = ['a', 'b', 'c'];
-    const aParameter: Parameter = {
-      id: 'test00',
-      description: {
-        de: 'Ein Text',
-        en: 'Some text',
-        fr: 'Some text but french',
-        it: 'Some text but Italian',
-      },
-      group: {
-        de: 'Wind',
-        en: 'wind',
-        fr: 'vent',
-        it: 'vento',
-      },
-    };
-    spyOn(service, 'getParametersForCollection').and.resolveTo([aParameter]);
+
+    stacApiService.getCollectionMetaCsvFile.and.resolveTo([testCsvParameter]);
 
     const parameters = await service.loadParameterForCollections(collections);
 
-    expect(parameters).toEqual(jasmine.arrayWithExactContents([aParameter, aParameter, aParameter]));
+    expect(parameters).toEqual(jasmine.arrayWithExactContents([testParameter, testParameter, testParameter]));
   });
 });

--- a/src/app/stac/service/parameter.service.ts
+++ b/src/app/stac/service/parameter.service.ts
@@ -1,22 +1,7 @@
 import {inject, Injectable} from '@angular/core';
 import {StacApiService} from './stac-api.service';
 import type {Parameter} from '../../shared/models/parameter';
-
-export interface CsvParameter {
-  parameterShortname: string;
-  parameterDescriptionDe: string;
-  parameterDescriptionFr: string;
-  parameterDescriptionIt: string;
-  parameterDescriptionEn: string;
-  parameterGroupDe: string;
-  parameterGroupFr: string;
-  parameterGroupIt: string;
-  parameterGroupEn: string;
-  parameterGranularity: 'T' | 'H' | 'D' | 'M' | 'Y';
-  parameterDecimals: `${number}`;
-  parameterDatatype: 'Integer' | 'Float';
-  parameterUnit: string;
-}
+import type {CsvParameter} from '../models/csv-parameter';
 
 @Injectable({
   providedIn: 'root',
@@ -29,12 +14,12 @@ export class ParameterService {
     return parameters.flat();
   }
 
-  public async getParametersForCollection(collection: string): Promise<Parameter[]> {
+  private async getParametersForCollection(collection: string): Promise<Parameter[]> {
     const csvParameters: CsvParameter[] = await this.stacApiService.getCollectionMetaCsvFile<CsvParameter>(collection, 'parameters');
     return csvParameters.map(this.transformCsvParameter);
   }
 
-  public transformCsvParameter(csvParameter: CsvParameter): Parameter {
+  private transformCsvParameter(csvParameter: CsvParameter): Parameter {
     return {
       id: csvParameter.parameterShortname.slice(0, -2),
       description: {

--- a/src/app/stac/service/station.service.spec.ts
+++ b/src/app/stac/service/station.service.spec.ts
@@ -1,0 +1,94 @@
+import {TestBed} from '@angular/core/testing';
+import {provideMockStore} from '@ngrx/store/testing';
+import {StationService} from './station.service';
+import type {Station} from '../../shared/models/station';
+import type {CsvStation} from './station.service';
+
+describe('StationService', () => {
+  let service: StationService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [provideMockStore()],
+    });
+    service = TestBed.inject(StationService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  it('should transform csvStations to internal type representation', () => {
+    const testValue: CsvStation = {
+      stationAbbr: 'TEST',
+      stationName: 'Test station',
+      stationCanton: '',
+      stationWigosId: '',
+      stationTypeDe: '',
+      stationTypeFr: '',
+      stationTypeIt: '',
+      stationTypeEn: '',
+      stationDataowner: '',
+      stationDataSince: '',
+      stationHeightMasl: '',
+      stationHeightBarometerMasl: '',
+      stationCoordinatesLv95East: '0',
+      stationCoordinatesLv95North: '0',
+      stationCoordinatesWgs84Lat: '0',
+      stationCoordinatesWgs84Lon: '0',
+      stationExpositionDe: '',
+      stationExpositionFr: '',
+      stationExpositionIt: '',
+      stationExpositionEn: '',
+      stationUrlDe: '',
+      stationUrlFr: '',
+      stationUrlIt: '',
+      stationUrlEn: '',
+    };
+    const result = service.transformCsvStation(testValue);
+    expect(result).toEqual({
+      id: 'TEST',
+      name: 'Test station',
+    } satisfies Station);
+  });
+
+  it('should get stations for each collection and write data to store', async () => {
+    const collections = ['a', 'b', 'c'];
+    const aStation: Station = {
+      id: 'test a',
+      name: 'Test station a',
+    };
+    const bStation: Station = {
+      id: 'test b',
+      name: 'Test station b',
+    };
+    const cStation: Station = {
+      id: 'test c',
+      name: 'Test station c',
+    };
+    spyOn(service, 'getStationForCollection')
+      .withArgs('a')
+      .and.resolveTo([aStation])
+      .withArgs('b')
+      .and.resolveTo([bStation])
+      .withArgs('c')
+      .and.resolveTo([cStation]);
+
+    const parameters = await service.loadStationsForCollections(collections);
+
+    expect(parameters).toEqual(jasmine.arrayWithExactContents([aStation, bStation, cStation]));
+  });
+
+  it('should merge stations with the same id for different collections', async () => {
+    const collections = ['a', 'b', 'c'];
+    const aStation: Station = {
+      id: 'test',
+      name: 'Test station',
+    };
+    spyOn(service, 'getStationForCollection').and.resolveTo([aStation]);
+
+    const parameters = await service.loadStationsForCollections(collections);
+
+    expect(parameters).toEqual(jasmine.arrayWithExactContents([aStation]));
+  });
+});

--- a/src/app/stac/service/station.service.spec.ts
+++ b/src/app/stac/service/station.service.spec.ts
@@ -1,15 +1,56 @@
 import {TestBed} from '@angular/core/testing';
 import {provideMockStore} from '@ngrx/store/testing';
+import {StacApiService} from './stac-api.service';
 import {StationService} from './station.service';
 import type {Station} from '../../shared/models/station';
-import type {CsvStation} from './station.service';
+import type {CsvStation} from '../models/csv-station';
+
+const testCsvStation: CsvStation = {
+  stationAbbr: 'TEST',
+  stationName: 'Test station',
+  stationCanton: '',
+  stationWigosId: '',
+  stationTypeDe: '',
+  stationTypeFr: '',
+  stationTypeIt: '',
+  stationTypeEn: '',
+  stationDataowner: '',
+  stationDataSince: '',
+  stationHeightMasl: '',
+  stationHeightBarometerMasl: '',
+  stationCoordinatesLv95East: '0',
+  stationCoordinatesLv95North: '0',
+  stationCoordinatesWgs84Lat: '0',
+  stationCoordinatesWgs84Lon: '0',
+  stationExpositionDe: '',
+  stationExpositionFr: '',
+  stationExpositionIt: '',
+  stationExpositionEn: '',
+  stationUrlDe: '',
+  stationUrlFr: '',
+  stationUrlIt: '',
+  stationUrlEn: '',
+};
+
+const testStation: Station = {
+  id: 'TEST',
+  name: 'Test station',
+};
 
 describe('StationService', () => {
   let service: StationService;
+  let stacApiService: jasmine.SpyObj<StacApiService>;
 
   beforeEach(() => {
+    stacApiService = jasmine.createSpyObj<StacApiService>('StacApiService', ['getCollectionMetaCsvFile']);
     TestBed.configureTestingModule({
-      providers: [provideMockStore()],
+      providers: [
+        provideMockStore(),
+        {
+          provide: StacApiService,
+          useValue: stacApiService,
+        },
+      ],
     });
     service = TestBed.inject(StationService);
   });
@@ -19,76 +60,52 @@ describe('StationService', () => {
   });
 
   it('should transform csvStations to internal type representation', () => {
-    const testValue: CsvStation = {
-      stationAbbr: 'TEST',
-      stationName: 'Test station',
-      stationCanton: '',
-      stationWigosId: '',
-      stationTypeDe: '',
-      stationTypeFr: '',
-      stationTypeIt: '',
-      stationTypeEn: '',
-      stationDataowner: '',
-      stationDataSince: '',
-      stationHeightMasl: '',
-      stationHeightBarometerMasl: '',
-      stationCoordinatesLv95East: '0',
-      stationCoordinatesLv95North: '0',
-      stationCoordinatesWgs84Lat: '0',
-      stationCoordinatesWgs84Lon: '0',
-      stationExpositionDe: '',
-      stationExpositionFr: '',
-      stationExpositionIt: '',
-      stationExpositionEn: '',
-      stationUrlDe: '',
-      stationUrlFr: '',
-      stationUrlIt: '',
-      stationUrlEn: '',
-    };
-    const result = service.transformCsvStation(testValue);
-    expect(result).toEqual({
-      id: 'TEST',
-      name: 'Test station',
-    } satisfies Station);
+    // transformCsvStation is private. To access it we need to use property access else TypeScript complains
+    // eslint-disable-next-line @typescript-eslint/dot-notation
+    const result = service['transformCsvStation'](testCsvStation);
+    expect(result).toEqual(testStation);
   });
 
   it('should get stations for each collection and write data to store', async () => {
     const collections = ['a', 'b', 'c'];
-    const aStation: Station = {
-      id: 'test a',
-      name: 'Test station a',
+    const aStation: CsvStation = {
+      ...testCsvStation,
+      stationAbbr: 'test a',
     };
-    const bStation: Station = {
-      id: 'test b',
-      name: 'Test station b',
+    const bStation: CsvStation = {
+      ...testCsvStation,
+      stationAbbr: 'test b',
     };
-    const cStation: Station = {
-      id: 'test c',
-      name: 'Test station c',
+    const cStation: CsvStation = {
+      ...testCsvStation,
+      stationAbbr: 'test c',
     };
-    spyOn(service, 'getStationForCollection')
-      .withArgs('a')
+    stacApiService.getCollectionMetaCsvFile
+      .withArgs('a', 'stations')
       .and.resolveTo([aStation])
-      .withArgs('b')
+      .withArgs('b', 'stations')
       .and.resolveTo([bStation])
-      .withArgs('c')
+      .withArgs('c', 'stations')
       .and.resolveTo([cStation]);
 
     const parameters = await service.loadStationsForCollections(collections);
 
-    expect(parameters).toEqual(jasmine.arrayWithExactContents([aStation, bStation, cStation]));
+    expect(parameters).toEqual(
+      jasmine.arrayWithExactContents([
+        {...testStation, id: aStation.stationAbbr},
+        {...testStation, id: bStation.stationAbbr},
+        {...testStation, id: cStation.stationAbbr},
+      ]),
+    );
   });
 
   it('should merge stations with the same id for different collections', async () => {
     const collections = ['a', 'b', 'c'];
-    const aStation: Station = {
-      id: 'test',
-      name: 'Test station',
-    };
-    spyOn(service, 'getStationForCollection').and.resolveTo([aStation]);
+
+    stacApiService.getCollectionMetaCsvFile.and.resolveTo([testCsvStation]);
 
     const parameters = await service.loadStationsForCollections(collections);
 
-    expect(parameters).toEqual(jasmine.arrayWithExactContents([aStation]));
+    expect(parameters).toEqual(jasmine.arrayWithExactContents([testStation]));
   });
 });

--- a/src/app/stac/service/station.service.ts
+++ b/src/app/stac/service/station.service.ts
@@ -1,0 +1,58 @@
+import {inject, Injectable} from '@angular/core';
+import {Station} from '../../shared/models/station';
+import {StacApiService} from './stac-api.service';
+
+export interface CsvStation {
+  stationAbbr: string;
+  stationName: string;
+  stationCanton: string;
+  stationWigosId: string;
+  stationTypeDe: string;
+  stationTypeFr: string;
+  stationTypeIt: string;
+  stationTypeEn: string;
+  stationDataowner: string;
+  stationDataSince: string;
+  stationHeightMasl: string;
+  stationHeightBarometerMasl: string;
+  stationCoordinatesLv95East: `${number}`;
+  stationCoordinatesLv95North: `${number}`;
+  stationCoordinatesWgs84Lat: `${number}`;
+  stationCoordinatesWgs84Lon: `${number}`;
+  stationExpositionDe: string;
+  stationExpositionFr: string;
+  stationExpositionIt: string;
+  stationExpositionEn: string;
+  stationUrlDe: string;
+  stationUrlFr: string;
+  stationUrlIt: string;
+  stationUrlEn: string;
+}
+
+@Injectable({
+  providedIn: 'root',
+})
+export class StationService {
+  private readonly stacApiService = inject(StacApiService);
+
+  public async loadStationsForCollections(collections: string[]): Promise<Station[]> {
+    const stations = await Promise.all(collections.map((collection) => this.getStationForCollection(collection)));
+    let result: Station[] = [];
+    stations.forEach(
+      (stationList) => (result = result.concat(stationList.filter((station) => !result.some((value) => value.id === station.id)))),
+    );
+    return result;
+  }
+
+  public async getStationForCollection(collection: string): Promise<Station[]> {
+    const csvStations: CsvStation[] = await this.stacApiService.getCollectionMetaCsvFile<CsvStation>(collection, 'stations');
+    return csvStations.map(this.transformCsvStation);
+  }
+
+  public transformCsvStation(csvStation: CsvStation) {
+    return {
+      id: csvStation.stationAbbr,
+      name: csvStation.stationName,
+    };
+  }
+}

--- a/src/app/stac/service/station.service.ts
+++ b/src/app/stac/service/station.service.ts
@@ -1,33 +1,7 @@
 import {inject, Injectable} from '@angular/core';
-import {Station} from '../../shared/models/station';
 import {StacApiService} from './stac-api.service';
-
-export interface CsvStation {
-  stationAbbr: string;
-  stationName: string;
-  stationCanton: string;
-  stationWigosId: string;
-  stationTypeDe: string;
-  stationTypeFr: string;
-  stationTypeIt: string;
-  stationTypeEn: string;
-  stationDataowner: string;
-  stationDataSince: string;
-  stationHeightMasl: string;
-  stationHeightBarometerMasl: string;
-  stationCoordinatesLv95East: `${number}`;
-  stationCoordinatesLv95North: `${number}`;
-  stationCoordinatesWgs84Lat: `${number}`;
-  stationCoordinatesWgs84Lon: `${number}`;
-  stationExpositionDe: string;
-  stationExpositionFr: string;
-  stationExpositionIt: string;
-  stationExpositionEn: string;
-  stationUrlDe: string;
-  stationUrlFr: string;
-  stationUrlIt: string;
-  stationUrlEn: string;
-}
+import type {Station} from '../../shared/models/station';
+import type {CsvStation} from '../models/csv-station';
 
 @Injectable({
   providedIn: 'root',
@@ -36,20 +10,20 @@ export class StationService {
   private readonly stacApiService = inject(StacApiService);
 
   public async loadStationsForCollections(collections: string[]): Promise<Station[]> {
-    const stations = await Promise.all(collections.map((collection) => this.getStationForCollection(collection)));
-    let result: Station[] = [];
-    stations.forEach(
-      (stationList) => (result = result.concat(stationList.filter((station) => !result.some((value) => value.id === station.id)))),
+    const stations = (await Promise.all(collections.map((collection) => this.getStationForCollection(collection)))).flat();
+    return stations.reduce(
+      (uniqueStations: Station[], station) =>
+        !uniqueStations.some((uniqueStation) => uniqueStation.id === station.id) ? [...uniqueStations, station] : uniqueStations,
+      [],
     );
-    return result;
   }
 
-  public async getStationForCollection(collection: string): Promise<Station[]> {
+  private async getStationForCollection(collection: string): Promise<Station[]> {
     const csvStations: CsvStation[] = await this.stacApiService.getCollectionMetaCsvFile<CsvStation>(collection, 'stations');
     return csvStations.map(this.transformCsvStation);
   }
 
-  public transformCsvStation(csvStation: CsvStation) {
+  private transformCsvStation(csvStation: CsvStation) {
     return {
       id: csvStation.stationAbbr,
       name: csvStation.stationName,

--- a/src/app/state/collection/actions/collection.action.ts
+++ b/src/app/state/collection/actions/collection.action.ts
@@ -1,0 +1,8 @@
+import {createActionGroup, props} from '@ngrx/store';
+
+export const collectionActions = createActionGroup({
+  source: 'Collections',
+  events: {
+    'Load collections': props<{collections: string[]}>(),
+  },
+});

--- a/src/app/state/index.ts
+++ b/src/app/state/index.ts
@@ -1,15 +1,23 @@
-import {Type} from '@angular/core';
-import {FunctionalEffect} from '@ngrx/effects';
-import {ActionReducerMap, MetaReducer} from '@ngrx/store';
-import {failLoadingCollectionParameters, loadCollectionParameters} from './parameters/effects/parameter.effects';
+import {failLoadingCollectionParameters, loadCollectionParameters, loadParameters} from './parameters/effects/parameter.effects';
 import {parameterFeature, parameterFeatureKey} from './parameters/reducers/parameter.reducer';
-import {ParameterState} from './parameters/states/parameter.state';
+import {loadCollectionStations, loadStations} from './stations/effects/station.effects';
+import {stationFeature, stationFeatureKey} from './stations/reducers/station.reducer';
+import type {Type} from '@angular/core';
+import type {FunctionalEffect} from '@ngrx/effects';
+import type {ActionReducerMap, MetaReducer} from '@ngrx/store';
+import type {ParameterState} from './parameters/states/parameter.state';
+import type {StationState} from './stations/states/station.state';
 
 export interface State {
   [parameterFeatureKey]: ParameterState;
+  [stationFeatureKey]: StationState;
 }
 export const reducers: ActionReducerMap<State> = {
   [parameterFeatureKey]: parameterFeature.reducer,
+  [stationFeatureKey]: stationFeature.reducer,
 };
-export const effects: (Type<unknown> | Record<string, FunctionalEffect>)[] = [{loadCollectionParameters, failLoadingCollectionParameters}];
+export const effects: (Type<unknown> | Record<string, FunctionalEffect>)[] = [
+  {loadCollectionParameters, loadParameters, failLoadingCollectionParameters},
+  {loadStations, loadCollectionStations},
+];
 export const metaReducers: MetaReducer<State>[] = [];

--- a/src/app/state/parameters/actions/parameter.action.ts
+++ b/src/app/state/parameters/actions/parameter.action.ts
@@ -6,7 +6,7 @@ export const parameterActions = createActionGroup({
   source: 'Parameters',
   events: {
     'Set loaded parameters': props<{parameters: Parameter[]}>(),
-    'Load parameter for collections': props<{collections: string[]}>(),
+    'Load parameters for collections': props<{collections: string[]}>(),
     'Set parameter loading error': errorProps(),
   },
 });

--- a/src/app/state/parameters/effects/parameter.effects.spec.ts
+++ b/src/app/state/parameters/effects/parameter.effects.spec.ts
@@ -4,9 +4,10 @@ import {MockStore, provideMockStore} from '@ngrx/store/testing';
 import {catchError, EMPTY, Observable, of} from 'rxjs';
 import {ParameterError} from '../../../shared/errors/parameter.error';
 import {ParameterService} from '../../../stac/service/parameter.service';
+import {collectionActions} from '../../collection/actions/collection.action';
 import {parameterActions} from '../actions/parameter.action';
 import {parameterFeature} from '../reducers/parameter.reducer';
-import {failLoadingCollectionParameters, loadCollectionParameters} from './parameter.effects';
+import {failLoadingCollectionParameters, loadCollectionParameters, loadParameters} from './parameter.effects';
 
 describe('ParameterEffects', () => {
   let actions$: Observable<Action>;
@@ -26,22 +27,31 @@ describe('ParameterEffects', () => {
     store.resetSelectors();
   });
 
-  it('should dispatch the SetParameter action when loading parameters for collections', (done) => {
+  it('should dispatch loadParameter action when loadCollection is dispatched', (done: DoneFn) => {
+    const collections = ['collection'];
+    actions$ = of(collectionActions.loadCollections({collections}));
+    loadCollectionParameters(actions$).subscribe((action) => {
+      expect(action).toEqual(parameterActions.loadParameterForCollections({collections}));
+      done();
+    });
+  });
+
+  it('should dispatch the SetParameter action when loading parameters for collections', (done: DoneFn) => {
     spyOn(parameterService, 'loadParameterForCollections').and.resolveTo([]);
     actions$ = of(parameterActions.loadParameterForCollections({collections: ['collection']}));
 
-    loadCollectionParameters(actions$, store, parameterService).subscribe((action) => {
+    loadParameters(actions$, store, parameterService).subscribe((action) => {
       expect(action).toEqual(parameterActions.setLoadedParameters({parameters: []}));
       done();
     });
   });
 
-  it('should not call the service if the data is already loaded', (done) => {
+  it('should not call the service if the data is already loaded', (done: DoneFn) => {
     spyOn(parameterService, 'loadParameterForCollections');
     store.overrideSelector(parameterFeature.selectLoadingState, 'loaded');
     actions$ = of(parameterActions.loadParameterForCollections({collections: ['collection']}));
 
-    loadCollectionParameters(actions$, store, parameterService).subscribe({
+    loadParameters(actions$, store, parameterService).subscribe({
       complete: () => {
         expect(parameterService.loadParameterForCollections).not.toHaveBeenCalled();
         done();
@@ -63,5 +73,16 @@ describe('ParameterEffects', () => {
         }),
       )
       .subscribe();
+  });
+
+  it('should set loading error if the service throws an error', (done: DoneFn) => {
+    const error = new Error('test');
+    spyOn(parameterService, 'loadParameterForCollections').and.rejectWith(error);
+    actions$ = of(parameterActions.loadParameterForCollections({collections: ['collection']}));
+
+    loadParameters(actions$, store, parameterService).subscribe((action) => {
+      expect(action).toEqual(parameterActions.setParameterLoadingError({error}));
+      done();
+    });
   });
 });

--- a/src/app/state/parameters/effects/parameter.effects.spec.ts
+++ b/src/app/state/parameters/effects/parameter.effects.spec.ts
@@ -31,14 +31,14 @@ describe('ParameterEffects', () => {
     const collections = ['collection'];
     actions$ = of(collectionActions.loadCollections({collections}));
     loadCollectionParameters(actions$).subscribe((action) => {
-      expect(action).toEqual(parameterActions.loadParameterForCollections({collections}));
+      expect(action).toEqual(parameterActions.loadParametersForCollections({collections}));
       done();
     });
   });
 
   it('should dispatch the SetParameter action when loading parameters for collections', (done: DoneFn) => {
     spyOn(parameterService, 'loadParameterForCollections').and.resolveTo([]);
-    actions$ = of(parameterActions.loadParameterForCollections({collections: ['collection']}));
+    actions$ = of(parameterActions.loadParametersForCollections({collections: ['collection']}));
 
     loadParameters(actions$, store, parameterService).subscribe((action) => {
       expect(action).toEqual(parameterActions.setLoadedParameters({parameters: []}));
@@ -49,7 +49,7 @@ describe('ParameterEffects', () => {
   it('should not call the service if the data is already loaded', (done: DoneFn) => {
     spyOn(parameterService, 'loadParameterForCollections');
     store.overrideSelector(parameterFeature.selectLoadingState, 'loaded');
-    actions$ = of(parameterActions.loadParameterForCollections({collections: ['collection']}));
+    actions$ = of(parameterActions.loadParametersForCollections({collections: ['collection']}));
 
     loadParameters(actions$, store, parameterService).subscribe({
       complete: () => {
@@ -78,7 +78,7 @@ describe('ParameterEffects', () => {
   it('should set loading error if the service throws an error', (done: DoneFn) => {
     const error = new Error('test');
     spyOn(parameterService, 'loadParameterForCollections').and.rejectWith(error);
-    actions$ = of(parameterActions.loadParameterForCollections({collections: ['collection']}));
+    actions$ = of(parameterActions.loadParametersForCollections({collections: ['collection']}));
 
     loadParameters(actions$, store, parameterService).subscribe((action) => {
       expect(action).toEqual(parameterActions.setParameterLoadingError({error}));

--- a/src/app/state/parameters/effects/parameter.effects.ts
+++ b/src/app/state/parameters/effects/parameter.effects.ts
@@ -5,10 +5,21 @@ import {Store} from '@ngrx/store';
 import {catchError, filter, from, map, of, switchMap, tap} from 'rxjs';
 import {ParameterError} from '../../../shared/errors/parameter.error';
 import {ParameterService} from '../../../stac/service/parameter.service';
+import {collectionActions} from '../../collection/actions/collection.action';
 import {parameterActions} from '../actions/parameter.action';
 import {parameterFeature} from '../reducers/parameter.reducer';
 
 export const loadCollectionParameters = createEffect(
+  (actions$ = inject(Actions)) => {
+    return actions$.pipe(
+      ofType(collectionActions.loadCollections),
+      map(({collections}) => parameterActions.loadParameterForCollections({collections})),
+    );
+  },
+  {functional: true},
+);
+
+export const loadParameters = createEffect(
   (actions$ = inject(Actions), store = inject(Store), parameterService = inject(ParameterService)) => {
     return actions$.pipe(
       ofType(parameterActions.loadParameterForCollections),

--- a/src/app/state/parameters/effects/parameter.effects.ts
+++ b/src/app/state/parameters/effects/parameter.effects.ts
@@ -13,7 +13,7 @@ export const loadCollectionParameters = createEffect(
   (actions$ = inject(Actions)) => {
     return actions$.pipe(
       ofType(collectionActions.loadCollections),
-      map(({collections}) => parameterActions.loadParameterForCollections({collections})),
+      map(({collections}) => parameterActions.loadParametersForCollections({collections})),
     );
   },
   {functional: true},
@@ -22,7 +22,7 @@ export const loadCollectionParameters = createEffect(
 export const loadParameters = createEffect(
   (actions$ = inject(Actions), store = inject(Store), parameterService = inject(ParameterService)) => {
     return actions$.pipe(
-      ofType(parameterActions.loadParameterForCollections),
+      ofType(parameterActions.loadParametersForCollections),
       concatLatestFrom(() => store.select(parameterFeature.selectLoadingState)),
       filter(([_, loadingState]) => loadingState !== 'loaded'),
       switchMap(([{collections}]) =>

--- a/src/app/state/parameters/reducers/parameter.reducer.spec.ts
+++ b/src/app/state/parameters/reducers/parameter.reducer.spec.ts
@@ -12,7 +12,7 @@ describe('Parameter Reducer', () => {
 
   it('should set loadingState to loading when loadParameterForCollections is dispatched and loading state is currently not loaded', () => {
     state = {...state, loadingState: 'error'};
-    const action = parameterActions.loadParameterForCollections({collections: ['test']});
+    const action = parameterActions.loadParametersForCollections({collections: ['test']});
     const result = parameterFeature.reducer(state, action);
 
     expect(result.loadingState).toBe('loading');
@@ -21,7 +21,7 @@ describe('Parameter Reducer', () => {
 
   it('should not change loadingState if it is already loaded when loadParameterForCollections is dispatched', () => {
     state = {...state, loadingState: 'loaded'};
-    const action = parameterActions.loadParameterForCollections({collections: ['test']});
+    const action = parameterActions.loadParametersForCollections({collections: ['test']});
     const result = parameterFeature.reducer(state, action);
 
     expect(result.loadingState).toBe('loaded');

--- a/src/app/state/parameters/reducers/parameter.reducer.ts
+++ b/src/app/state/parameters/reducers/parameter.reducer.ts
@@ -14,7 +14,7 @@ export const parameterFeature = createFeature({
   reducer: createReducer(
     initialState,
     on(
-      parameterActions.loadParameterForCollections,
+      parameterActions.loadParametersForCollections,
       (state): ParameterState => ({
         ...state,
         loadingState: state.loadingState !== 'loaded' ? 'loading' : state.loadingState,

--- a/src/app/state/stations/actions/station.action.ts
+++ b/src/app/state/stations/actions/station.action.ts
@@ -6,7 +6,7 @@ export const stationActions = createActionGroup({
   source: 'Stations',
   events: {
     'Set loaded stations': props<{stations: Station[]}>(),
-    'Load station for collections': props<{collections: string[]}>(),
+    'Load stations for collections': props<{collections: string[]}>(),
     'Set station loading error': errorProps(),
   },
 });

--- a/src/app/state/stations/actions/station.action.ts
+++ b/src/app/state/stations/actions/station.action.ts
@@ -1,0 +1,12 @@
+import {createActionGroup, props} from '@ngrx/store';
+import {Station} from '../../../shared/models/station';
+import {errorProps} from '../../utils/error-props.util';
+
+export const stationActions = createActionGroup({
+  source: 'Stations',
+  events: {
+    'Set loaded stations': props<{stations: Station[]}>(),
+    'Load station for collections': props<{collections: string[]}>(),
+    'Set station loading error': errorProps(),
+  },
+});

--- a/src/app/state/stations/effects/station.effects.spec.ts
+++ b/src/app/state/stations/effects/station.effects.spec.ts
@@ -30,14 +30,14 @@ describe('ParameterEffects', () => {
     const collections = ['collection'];
     actions$ = of(collectionActions.loadCollections({collections}));
     loadCollectionStations(actions$).subscribe((action) => {
-      expect(action).toEqual(stationActions.loadStationForCollections({collections}));
+      expect(action).toEqual(stationActions.loadStationsForCollections({collections}));
       done();
     });
   });
 
   it('should dispatch the setStations action when loading stations for collections', (done: DoneFn) => {
     spyOn(stationService, 'loadStationsForCollections').and.resolveTo([]);
-    actions$ = of(stationActions.loadStationForCollections({collections: ['collection']}));
+    actions$ = of(stationActions.loadStationsForCollections({collections: ['collection']}));
 
     loadStations(actions$, store, stationService).subscribe((action) => {
       expect(action).toEqual(stationActions.setLoadedStations({stations: []}));
@@ -48,7 +48,7 @@ describe('ParameterEffects', () => {
   it('should not call the service if the data is already loaded', (done: DoneFn) => {
     spyOn(stationService, 'loadStationsForCollections');
     store.overrideSelector(stationFeature.selectLoadingState, 'loaded');
-    actions$ = of(stationActions.loadStationForCollections({collections: ['collection']}));
+    actions$ = of(stationActions.loadStationsForCollections({collections: ['collection']}));
 
     loadStations(actions$, store, stationService).subscribe({
       complete: () => {
@@ -61,7 +61,7 @@ describe('ParameterEffects', () => {
   it('should set loading error if the service throws an error', (done: DoneFn) => {
     const error = new Error('test');
     spyOn(stationService, 'loadStationsForCollections').and.rejectWith(error);
-    actions$ = of(stationActions.loadStationForCollections({collections: ['collection']}));
+    actions$ = of(stationActions.loadStationsForCollections({collections: ['collection']}));
 
     loadStations(actions$, store, stationService).subscribe((action) => {
       expect(action).toEqual(stationActions.setStationLoadingError({error}));

--- a/src/app/state/stations/effects/station.effects.spec.ts
+++ b/src/app/state/stations/effects/station.effects.spec.ts
@@ -1,0 +1,71 @@
+import {TestBed} from '@angular/core/testing';
+import {Action} from '@ngrx/store';
+import {MockStore, provideMockStore} from '@ngrx/store/testing';
+import {Observable, of} from 'rxjs';
+import {StationService} from '../../../stac/service/station.service';
+import {collectionActions} from '../../collection/actions/collection.action';
+import {stationActions} from '../actions/station.action';
+import {stationFeature} from '../reducers/station.reducer';
+import {loadCollectionStations, loadStations} from './station.effects';
+
+describe('ParameterEffects', () => {
+  let actions$: Observable<Action>;
+  let store: MockStore;
+  let stationService: StationService;
+
+  beforeEach(() => {
+    actions$ = new Observable<Action>();
+    TestBed.configureTestingModule({
+      providers: [provideMockStore()],
+    });
+    store = TestBed.inject(MockStore);
+    stationService = TestBed.inject(StationService);
+  });
+
+  afterEach(() => {
+    store.resetSelectors();
+  });
+
+  it('should dispatch loadStations action when loadCollection is dispatched', (done: DoneFn) => {
+    const collections = ['collection'];
+    actions$ = of(collectionActions.loadCollections({collections}));
+    loadCollectionStations(actions$).subscribe((action) => {
+      expect(action).toEqual(stationActions.loadStationForCollections({collections}));
+      done();
+    });
+  });
+
+  it('should dispatch the setStations action when loading stations for collections', (done: DoneFn) => {
+    spyOn(stationService, 'loadStationsForCollections').and.resolveTo([]);
+    actions$ = of(stationActions.loadStationForCollections({collections: ['collection']}));
+
+    loadStations(actions$, store, stationService).subscribe((action) => {
+      expect(action).toEqual(stationActions.setLoadedStations({stations: []}));
+      done();
+    });
+  });
+
+  it('should not call the service if the data is already loaded', (done: DoneFn) => {
+    spyOn(stationService, 'loadStationsForCollections');
+    store.overrideSelector(stationFeature.selectLoadingState, 'loaded');
+    actions$ = of(stationActions.loadStationForCollections({collections: ['collection']}));
+
+    loadStations(actions$, store, stationService).subscribe({
+      complete: () => {
+        expect(stationService.loadStationsForCollections).not.toHaveBeenCalled();
+        done();
+      },
+    });
+  });
+
+  it('should set loading error if the service throws an error', (done: DoneFn) => {
+    const error = new Error('test');
+    spyOn(stationService, 'loadStationsForCollections').and.rejectWith(error);
+    actions$ = of(stationActions.loadStationForCollections({collections: ['collection']}));
+
+    loadStations(actions$, store, stationService).subscribe((action) => {
+      expect(action).toEqual(stationActions.setStationLoadingError({error}));
+      done();
+    });
+  });
+});

--- a/src/app/state/stations/effects/station.effects.ts
+++ b/src/app/state/stations/effects/station.effects.ts
@@ -12,7 +12,7 @@ export const loadCollectionStations = createEffect(
   (actions$ = inject(Actions)) => {
     return actions$.pipe(
       ofType(collectionActions.loadCollections),
-      map(({collections}) => stationActions.loadStationForCollections({collections})),
+      map(({collections}) => stationActions.loadStationsForCollections({collections})),
     );
   },
   {functional: true},
@@ -21,7 +21,7 @@ export const loadCollectionStations = createEffect(
 export const loadStations = createEffect(
   (actions$ = inject(Actions), store = inject(Store), stationService = inject(StationService)) => {
     return actions$.pipe(
-      ofType(stationActions.loadStationForCollections),
+      ofType(stationActions.loadStationsForCollections),
       concatLatestFrom(() => store.select(stationFeature.selectLoadingState)),
       filter(([_, loadingState]) => loadingState !== 'loaded'),
       switchMap(([{collections}]) =>

--- a/src/app/state/stations/effects/station.effects.ts
+++ b/src/app/state/stations/effects/station.effects.ts
@@ -1,0 +1,36 @@
+import {inject} from '@angular/core';
+import {Actions, createEffect, ofType} from '@ngrx/effects';
+import {concatLatestFrom} from '@ngrx/operators';
+import {Store} from '@ngrx/store';
+import {catchError, filter, from, map, of, switchMap} from 'rxjs';
+import {StationService} from '../../../stac/service/station.service';
+import {collectionActions} from '../../collection/actions/collection.action';
+import {stationActions} from '../actions/station.action';
+import {stationFeature} from '../reducers/station.reducer';
+
+export const loadCollectionStations = createEffect(
+  (actions$ = inject(Actions)) => {
+    return actions$.pipe(
+      ofType(collectionActions.loadCollections),
+      map(({collections}) => stationActions.loadStationForCollections({collections})),
+    );
+  },
+  {functional: true},
+);
+
+export const loadStations = createEffect(
+  (actions$ = inject(Actions), store = inject(Store), stationService = inject(StationService)) => {
+    return actions$.pipe(
+      ofType(stationActions.loadStationForCollections),
+      concatLatestFrom(() => store.select(stationFeature.selectLoadingState)),
+      filter(([_, loadingState]) => loadingState !== 'loaded'),
+      switchMap(([{collections}]) =>
+        from(stationService.loadStationsForCollections(collections)).pipe(
+          map((stations) => stationActions.setLoadedStations({stations})),
+          catchError((error: unknown) => of(stationActions.setStationLoadingError({error}))),
+        ),
+      ),
+    );
+  },
+  {functional: true},
+);

--- a/src/app/state/stations/reducers/station.reducer.spec.ts
+++ b/src/app/state/stations/reducers/station.reducer.spec.ts
@@ -1,0 +1,51 @@
+import {stationActions} from '../actions/station.action';
+import {initialState, stationFeature} from './station.reducer';
+import type {Station} from '../../../shared/models/station';
+import type {StationState} from '../states/station.state';
+
+describe('Station Reducer', () => {
+  let state: StationState;
+
+  beforeEach(() => {
+    state = initialState;
+  });
+
+  it('should set loadingState to loading when loadStationForCollections is dispatched and loading state is currently not loaded', () => {
+    state = {...state, loadingState: 'error'};
+    const action = stationActions.loadStationForCollections({collections: ['test']});
+    const result = stationFeature.reducer(state, action);
+
+    expect(result.loadingState).toBe('loading');
+    expect(result.stations).toEqual([]);
+  });
+
+  it('should not change loadingState if it is already loaded when loadStationForCollections is dispatched', () => {
+    state = {...state, loadingState: 'loaded'};
+    const action = stationActions.loadStationForCollections({collections: ['test']});
+    const result = stationFeature.reducer(state, action);
+
+    expect(result.loadingState).toBe('loaded');
+    expect(result.stations).toEqual([]);
+  });
+
+  it('should set stations and loadingState to loaded when setLoadedStations is dispatched', () => {
+    const stations: Station[] = [
+      {
+        id: 'test-station-id',
+        name: 'Test station name',
+      },
+    ];
+    const action = stationActions.setLoadedStations({stations});
+    const result = stationFeature.reducer(state, action);
+
+    expect(result.loadingState).toBe('loaded');
+    expect(result.stations).toEqual(stations);
+  });
+
+  it('should reset to initialState and set loadingState to error when setStationLoadingError is dispatched', () => {
+    const action = stationActions.setStationLoadingError({});
+    const result = stationFeature.reducer(state, action);
+
+    expect(result).toEqual({...initialState, loadingState: 'error'});
+  });
+});

--- a/src/app/state/stations/reducers/station.reducer.spec.ts
+++ b/src/app/state/stations/reducers/station.reducer.spec.ts
@@ -12,7 +12,7 @@ describe('Station Reducer', () => {
 
   it('should set loadingState to loading when loadStationForCollections is dispatched and loading state is currently not loaded', () => {
     state = {...state, loadingState: 'error'};
-    const action = stationActions.loadStationForCollections({collections: ['test']});
+    const action = stationActions.loadStationsForCollections({collections: ['test']});
     const result = stationFeature.reducer(state, action);
 
     expect(result.loadingState).toBe('loading');
@@ -21,7 +21,7 @@ describe('Station Reducer', () => {
 
   it('should not change loadingState if it is already loaded when loadStationForCollections is dispatched', () => {
     state = {...state, loadingState: 'loaded'};
-    const action = stationActions.loadStationForCollections({collections: ['test']});
+    const action = stationActions.loadStationsForCollections({collections: ['test']});
     const result = stationFeature.reducer(state, action);
 
     expect(result.loadingState).toBe('loaded');

--- a/src/app/state/stations/reducers/station.reducer.ts
+++ b/src/app/state/stations/reducers/station.reducer.ts
@@ -14,7 +14,7 @@ export const stationFeature = createFeature({
   reducer: createReducer(
     initialState,
     on(
-      stationActions.loadStationForCollections,
+      stationActions.loadStationsForCollections,
       (state): StationState => ({
         ...state,
         loadingState: state.loadingState !== 'loaded' ? 'loading' : state.loadingState,

--- a/src/app/state/stations/reducers/station.reducer.ts
+++ b/src/app/state/stations/reducers/station.reducer.ts
@@ -1,0 +1,39 @@
+import {createFeature, createReducer, on} from '@ngrx/store';
+import {stationActions} from '../actions/station.action';
+import {StationState} from '../states/station.state';
+
+export const stationFeatureKey = 'stations';
+
+export const initialState: StationState = {
+  stations: [],
+  loadingState: undefined,
+};
+
+export const stationFeature = createFeature({
+  name: stationFeatureKey,
+  reducer: createReducer(
+    initialState,
+    on(
+      stationActions.loadStationForCollections,
+      (state): StationState => ({
+        ...state,
+        loadingState: state.loadingState !== 'loaded' ? 'loading' : state.loadingState,
+      }),
+    ),
+    on(
+      stationActions.setLoadedStations,
+      (state, {stations}): StationState => ({
+        ...state,
+        loadingState: 'loaded',
+        stations: stations,
+      }),
+    ),
+    on(
+      stationActions.setStationLoadingError,
+      (): StationState => ({
+        ...initialState,
+        loadingState: 'error',
+      }),
+    ),
+  ),
+});

--- a/src/app/state/stations/states/station.state.ts
+++ b/src/app/state/stations/states/station.state.ts
@@ -1,0 +1,7 @@
+import {LoadingState} from '../../../shared/models/loading-state';
+import {Station} from '../../../shared/models/station';
+
+export interface StationState {
+  stations: Station[];
+  loadingState: LoadingState;
+}


### PR DESCRIPTION
This service loads all available stations for the given collections and returns the merged values. It is written analogously to the parameter service. The effects for the station store fetch the stations from the service and put it in the store. The service transforms the CSV entries to the internal representation.

When loading a collection both the parameters and the stations have to be loaded all the time. This is now done by using a collection action that triggers both effects for station and parameters.