### PR TITLE
Scope states with measurementDataType

### DIFF
--- a/public/i18n/de.json
+++ b/public/i18n/de.json
@@ -1,5 +1,7 @@
 {
   "errorTest": "Fehler Test",
+  "form.measurementDataType.normal": "Messdaten",
+  "form.measurementDataType.homogenous": "Homogene Messreihen",
   "form.stepper.station.label": "Missing value for 'form.stepper.station.label'",
   "form.stepper.next": "Weiter",
   "form.stepper.interval.label": "Missing value for 'form.stepper.interval.label'",
@@ -18,7 +20,7 @@
   "overview_file_size": "Missing value for 'overview_file_size'",
   "download-asset": "Missing value for 'download-asset'",
   "download-metadata": "Missing value for 'download-metadata'",
+  "station.load.error": "Missing value for 'station.load.error'",
   "parameter.load.error": "Fehler beim Laden der Parameter",
-  "parameter-station-mapping.load.error": "Missing value for 'parameter-station-mapping.load.error'",
-  "station.load.error": "Missing value for 'station.load.error'"
+  "parameter-station-mapping.load.error": "Missing value for 'parameter-station-mapping.load.error'"
 }

--- a/public/i18n/de.json
+++ b/public/i18n/de.json
@@ -1,7 +1,8 @@
 {
   "errorTest": "Fehler Test",
-  "form.measurementDataType.normal": "Messdaten",
-  "form.measurementDataType.homogenous": "Homogene Messreihen",
+  "form.measurement-data-type.normal": "Messdaten",
+  "form.measurement-data-type.homogenous": "Homogene Messreihen",
+  "form.measurement-data-type.aria-label": "Missing value for 'form.measurement-data-type.aria-label'",
   "form.stepper.station.label": "Missing value for 'form.stepper.station.label'",
   "form.stepper.next": "Weiter",
   "form.stepper.interval.label": "Missing value for 'form.stepper.interval.label'",

--- a/public/i18n/en.json
+++ b/public/i18n/en.json
@@ -1,5 +1,7 @@
 {
   "errorTest": "Test Error",
+  "form.measurementDataType.normal": "Missing value for 'form.measurementDataType.normal'",
+  "form.measurementDataType.homogenous": "Missing value for 'form.measurementDataType.homogenous'",
   "form.stepper.station.label": "Missing value for 'form.stepper.station.label'",
   "form.stepper.next": "Continue",
   "form.stepper.interval.label": "Missing value for 'form.stepper.interval.label'",
@@ -18,7 +20,7 @@
   "overview_file_size": "Missing value for 'overview_file_size'",
   "download-asset": "Missing value for 'download-asset'",
   "download-metadata": "Missing value for 'download-metadata'",
+  "station.load.error": "Missing value for 'station.load.error'",
   "parameter.load.error": "Error loading parameters",
-  "parameter-station-mapping.load.error": "Missing value for 'parameter-station-mapping.load.error'",
-  "station.load.error": "Missing value for 'station.load.error'"
+  "parameter-station-mapping.load.error": "Missing value for 'parameter-station-mapping.load.error'"
 }

--- a/public/i18n/en.json
+++ b/public/i18n/en.json
@@ -1,7 +1,8 @@
 {
   "errorTest": "Test Error",
-  "form.measurementDataType.normal": "Missing value for 'form.measurementDataType.normal'",
-  "form.measurementDataType.homogenous": "Missing value for 'form.measurementDataType.homogenous'",
+  "form.measurement-data-type.normal": "Missing value for 'form.measurementDataType.normal'",
+  "form.measurement-data-type.homogenous": "Missing value for 'form.measurementDataType.homogenous'",
+  "form.measurement-data-type.aria-label": "Missing value for 'form.measurement-data-type.aria-label'",
   "form.stepper.station.label": "Missing value for 'form.stepper.station.label'",
   "form.stepper.next": "Continue",
   "form.stepper.interval.label": "Missing value for 'form.stepper.interval.label'",

--- a/public/i18n/fr.json
+++ b/public/i18n/fr.json
@@ -1,5 +1,7 @@
 {
   "errorTest": "Missing value for 'Test Error'",
+  "form.measurementDataType.normal": "Missing value for 'form.measurementDataType.normal'",
+  "form.measurementDataType.homogenous": "Missing value for 'form.measurementDataType.homogenous'",
   "form.stepper.station.label": "Missing value for 'form.stepper.station.label'",
   "form.stepper.next": "Missing value for 'form.stepper.next'",
   "form.stepper.interval.label": "Missing value for 'form.stepper.interval.label'",
@@ -18,7 +20,7 @@
   "overview_file_size": "Missing value for 'overview_file_size'",
   "download-asset": "Missing value for 'download-asset'",
   "download-metadata": "Missing value for 'download-metadata'",
+  "station.load.error": "Missing value for 'station.load.error'",
   "parameter.load.error": "Erreur lors du chargement des paramètres",
-  "parameter-station-mapping.load.error": "Missing value for 'parameter-station-mapping.load.error'",
-  "station.load.error": "Missing value for 'station.load.error'"
+  "parameter-station-mapping.load.error": "Missing value for 'parameter-station-mapping.load.error'"
 }

--- a/public/i18n/fr.json
+++ b/public/i18n/fr.json
@@ -1,7 +1,8 @@
 {
   "errorTest": "Missing value for 'Test Error'",
-  "form.measurementDataType.normal": "Missing value for 'form.measurementDataType.normal'",
-  "form.measurementDataType.homogenous": "Missing value for 'form.measurementDataType.homogenous'",
+  "form.measurement-data-type.normal": "Missing value for 'form.measurementDataType.normal'",
+  "form.measurement-data-type.homogenous": "Missing value for 'form.measurementDataType.homogenous'",
+  "form.measurement-data-type.aria-label": "Missing value for 'form.measurement-data-type.aria-label'",
   "form.stepper.station.label": "Missing value for 'form.stepper.station.label'",
   "form.stepper.next": "Missing value for 'form.stepper.next'",
   "form.stepper.interval.label": "Missing value for 'form.stepper.interval.label'",

--- a/public/i18n/it.json
+++ b/public/i18n/it.json
@@ -1,5 +1,7 @@
 {
   "errorTest": "Missing value for 'Test Error'",
+  "form.measurementDataType.normal": "Missing value for 'form.measurementDataType.normal'",
+  "form.measurementDataType.homogenous": "Missing value for 'form.measurementDataType.homogenous'",
   "form.stepper.station.label": "Missing value for 'form.stepper.station.label'",
   "form.stepper.next": "Missing value for 'form.stepper.next'",
   "form.stepper.interval.label": "Missing value for 'form.stepper.interval.label'",
@@ -18,7 +20,7 @@
   "overview_file_size": "Missing value for 'overview_file_size'",
   "download-asset": "Missing value for 'download-asset'",
   "download-metadata": "Missing value for 'download-metadata'",
+  "station.load.error": "Missing value for 'station.load.error'",
   "parameter.load.error": "Errore durante il caricamento dei parametri",
-  "parameter-station-mapping.load.error": "Missing value for 'parameter-station-mapping.load.error'",
-  "station.load.error": "Missing value for 'station.load.error'"
+  "parameter-station-mapping.load.error": "Missing value for 'parameter-station-mapping.load.error'"
 }

--- a/public/i18n/it.json
+++ b/public/i18n/it.json
@@ -1,7 +1,8 @@
 {
   "errorTest": "Missing value for 'Test Error'",
-  "form.measurementDataType.normal": "Missing value for 'form.measurementDataType.normal'",
-  "form.measurementDataType.homogenous": "Missing value for 'form.measurementDataType.homogenous'",
+  "form.measurement-data-type.normal": "Missing value for 'form.measurementDataType.normal'",
+  "form.measurement-data-type.homogenous": "Missing value for 'form.measurementDataType.homogenous'",
+  "form.measurement-data-type.aria-label": "Missing value for 'form.measurement-data-type.aria-label'",
   "form.stepper.station.label": "Missing value for 'form.stepper.station.label'",
   "form.stepper.next": "Missing value for 'form.stepper.next'",
   "form.stepper.interval.label": "Missing value for 'form.stepper.interval.label'",

--- a/src/app/data-selection-form/data-selection-form.component.html
+++ b/src/app/data-selection-form/data-selection-form.component.html
@@ -4,12 +4,22 @@
       <mat-button-toggle [checked]="true" (click)="changeLanguage('de')">German</mat-button-toggle>
       <mat-button-toggle (click)="changeLanguage('en')">English</mat-button-toggle>
     </mat-button-toggle-group>
-    <button mat-stroked-button (click)="testCsv()">csv</button>
     <button mat-stroked-button color="warn" (click)="testError()">{{ t('errorTest') }}</button>
   </div>
   <hr />
+  <div>
+    <mat-button-toggle-group
+      aria-label="Data measurement"
+      (change)="setSelectedMeasurementDataType($event.value); stepper.reset()"
+      [value]="selectedMeasurementDataType$ | async"
+      hideSingleSelectionIndicator="true"
+    >
+      <mat-button-toggle value="normal">{{ t('form.measurementDataType.normal') }}</mat-button-toggle>
+      <mat-button-toggle value="homogenous">{{ t('form.measurementDataType.homogenous') }}</mat-button-toggle>
+    </mat-button-toggle-group>
+  </div>
 
-  <mat-vertical-stepper [linear]="true">
+  <mat-vertical-stepper [linear]="true" #stepper>
     <mat-step [completed]="(selectedParameterGroup$ | async) !== null">
       <ng-template matStepLabel>{{ t('form.stepper.station.label') }}</ng-template>
       <app-parameter-list></app-parameter-list>

--- a/src/app/data-selection-form/data-selection-form.component.html
+++ b/src/app/data-selection-form/data-selection-form.component.html
@@ -9,13 +9,13 @@
   <hr />
   <div>
     <mat-button-toggle-group
-      aria-label="Data measurement"
+      [attr.aria-label]="t('form.measurement-data-type.aria-label')"
       (change)="setSelectedMeasurementDataType($event.value); stepper.reset()"
       [value]="selectedMeasurementDataType$ | async"
       hideSingleSelectionIndicator="true"
     >
-      <mat-button-toggle value="normal">{{ t('form.measurementDataType.normal') }}</mat-button-toggle>
-      <mat-button-toggle value="homogenous">{{ t('form.measurementDataType.homogenous') }}</mat-button-toggle>
+      <mat-button-toggle value="normal">{{ t('form.measurement-data-type.normal') }}</mat-button-toggle>
+      <mat-button-toggle value="homogenous">{{ t('form.measurement-data-type.homogenous') }}</mat-button-toggle>
     </mat-button-toggle-group>
   </div>
 

--- a/src/app/data-selection-form/data-selection-form.component.ts
+++ b/src/app/data-selection-form/data-selection-form.component.ts
@@ -1,12 +1,14 @@
 import {AsyncPipe} from '@angular/common';
-import {Component, inject} from '@angular/core';
+import {Component, inject, OnInit} from '@angular/core';
 import {MatButton} from '@angular/material/button';
 import {MatButtonToggle, MatButtonToggleGroup} from '@angular/material/button-toggle';
 import {MatStepperModule} from '@angular/material/stepper';
 import {TranslocoModule, TranslocoService} from '@jsverse/transloco';
 import {Store} from '@ngrx/store';
 import {MapContainerComponent} from '../map/components/map-container/map-container.component';
-import {collectionActions} from '../state/collection/actions/collection.action';
+import {collectionConfig} from '../shared/configs/collections.config';
+import {MeasurementDataType} from '../shared/models/measurement-data-type';
+import {formActions} from '../state/form/actions/form.actions';
 import {formFeature} from '../state/form/reducers/form.reducer';
 import {DownloadAssetComponent} from './components/download-asset/download-asset.component';
 import {IntervalSelectionComponent} from './components/interval-selection/interval-selection.component';
@@ -35,13 +37,18 @@ import type {Language} from '../shared/models/language';
   templateUrl: './data-selection-form.component.html',
   styleUrl: './data-selection-form.component.scss',
 })
-export class DataSelectionFormComponent {
+export class DataSelectionFormComponent implements OnInit {
   private readonly translocoService = inject(TranslocoService);
   private readonly store = inject(Store);
 
   protected readonly selectedParameterGroup$ = this.store.select(formFeature.selectSelectedParameterGroupId);
   protected readonly selectedSelectedDataInterval$ = this.store.select(formFeature.selectSelectedDataInterval);
   protected readonly selectedSelectedTimeRange$ = this.store.select(formFeature.selectSelectedTimeRange);
+  protected readonly selectedMeasurementDataType$ = this.store.select(formFeature.selectSelectedMeasurementDataType);
+
+  public ngOnInit(): void {
+    this.store.dispatch(formActions.setSelectedMeasurementDataType({measurementDataType: collectionConfig.defaultMeasurementDataType}));
+  }
 
   protected changeLanguage(language: Language): void {
     this.translocoService.setActiveLang(language);
@@ -51,7 +58,7 @@ export class DataSelectionFormComponent {
     throw new Error('Test');
   }
 
-  protected testCsv(): void {
-    this.store.dispatch(collectionActions.loadCollections({collections: ['ch.meteoschweiz.ogd-smn', 'ch.meteoschweiz.ogd-smn-precip']}));
+  protected setSelectedMeasurementDataType(measurementDataType: MeasurementDataType): void {
+    this.store.dispatch(formActions.setSelectedMeasurementDataType({measurementDataType}));
   }
 }

--- a/src/app/shared/configs/collections.config.ts
+++ b/src/app/shared/configs/collections.config.ts
@@ -6,7 +6,6 @@ export const collectionConfig = {
       'ch.meteoschweiz.ogd-smn',
       'ch.meteoschweiz.ogd-smn-precip',
       'ch.meteoschweiz.ogd-smn-tower',
-      // 'ch.meteoschweiz.ogd-smn-soil', // Does not yet have datainventory.csv
       'ch.meteoschweiz.ogd-nime',
       'ch.meteoschweiz.ogd-tot',
       'ch.meteoschweiz.ogd-pollen',
@@ -16,4 +15,4 @@ export const collectionConfig = {
     homogenous: ['ch.meteoschweiz.ogd-nbcn', 'ch.meteoschweiz.ogd-nbcn-precip'],
   },
   defaultMeasurementDataType: 'normal',
-} satisfies CollectionsConfig;
+} as const satisfies CollectionsConfig;

--- a/src/app/shared/configs/collections.config.ts
+++ b/src/app/shared/configs/collections.config.ts
@@ -1,0 +1,19 @@
+import {CollectionsConfig} from '../models/configs/collections-config';
+
+export const collectionConfig = {
+  collections: {
+    normal: [
+      'ch.meteoschweiz.ogd-smn',
+      'ch.meteoschweiz.ogd-smn-precip',
+      'ch.meteoschweiz.ogd-smn-tower',
+      // 'ch.meteoschweiz.ogd-smn-soil', // Does not yet have datainventory.csv
+      'ch.meteoschweiz.ogd-nime',
+      'ch.meteoschweiz.ogd-tot',
+      'ch.meteoschweiz.ogd-pollen',
+      'ch.meteoschweiz.ogd-obs',
+      'ch.meteoschweiz.ogd-phenology',
+    ],
+    homogenous: ['ch.meteoschweiz.ogd-nbcn', 'ch.meteoschweiz.ogd-nbcn-precip'],
+  },
+  defaultMeasurementDataType: 'normal',
+} satisfies CollectionsConfig;

--- a/src/app/shared/models/configs/collections-config.ts
+++ b/src/app/shared/models/configs/collections-config.ts
@@ -1,0 +1,6 @@
+import {MeasurementDataType} from '../measurement-data-type';
+
+export interface CollectionsConfig {
+  collections: Record<MeasurementDataType, string[]>;
+  defaultMeasurementDataType: MeasurementDataType;
+}

--- a/src/app/shared/models/measurement-data-type.ts
+++ b/src/app/shared/models/measurement-data-type.ts
@@ -1,0 +1,2 @@
+export const measurementDataTypes = ['normal', 'homogenous'] as const;
+export type MeasurementDataType = (typeof measurementDataTypes)[number];

--- a/src/app/stac/service/stac-api.service.ts
+++ b/src/app/stac/service/stac-api.service.ts
@@ -18,15 +18,15 @@ export class StacApiService {
 
     const collection = collectionResponse.data;
     if (collection == null) {
-      throw new Error('Collection was null');
+      throw new Error(`Collection was null. Collection: ${collectionName}, metaFile: ${metaFile}`);
     }
     if (collection.assets == null) {
-      throw new Error('Collection did not contain any assets');
+      throw new Error(`Collection did not contain any assets. Collection: ${collectionName}, metaFile: ${metaFile}`);
     }
 
     const metaDataFileUrl = Object.entries(collection.assets).find(([key]) => key.includes(metaFile))?.[1]?.href;
     if (!metaDataFileUrl) {
-      throw new Error('Could not find URL for meta data CSV');
+      throw new Error(`Could not find URL for meta data CSV. Collection: ${collectionName}, metaFile: ${metaFile}`);
     }
 
     const parsedResult = new Promise<T[]>((resolve) => {

--- a/src/app/state/collection/actions/collection.action.ts
+++ b/src/app/state/collection/actions/collection.action.ts
@@ -1,8 +1,9 @@
 import {createActionGroup, props} from '@ngrx/store';
+import {MeasurementDataType} from '../../../shared/models/measurement-data-type';
 
 export const collectionActions = createActionGroup({
   source: 'Collections',
   events: {
-    'Load collections': props<{collections: string[]}>(),
+    'Load collections': props<{collections: string[]; measurementDataType: MeasurementDataType}>(),
   },
 });

--- a/src/app/state/form/actions/form.actions.ts
+++ b/src/app/state/form/actions/form.actions.ts
@@ -1,12 +1,14 @@
 import {createActionGroup, props} from '@ngrx/store';
-import {FormState} from '../states/form.state';
+import type {DataInterval} from '../../../shared/models/interval';
+import type {MeasurementDataType} from '../../../shared/models/measurement-data-type';
+import type {TimeRange} from '../../../shared/models/time-range';
 
 export const formActions = createActionGroup({
   source: 'Form',
   events: {
-    'Set selected parameters': props<{parameterGroupId: FormState['selectedParameterGroupId']}>(),
-    'Set selected dataInterval': props<{dataInterval: FormState['selectedDataInterval']}>(),
-    'Set selected time range': props<{timeRange: FormState['selectedTimeRange']}>(),
-    'Set selected measurement data type': props<{measurementDataType: FormState['selectedMeasurementDataType']}>(),
+    'Set selected parameters': props<{parameterGroupId: string | null}>(),
+    'Set selected dataInterval': props<{dataInterval: DataInterval}>(),
+    'Set selected time range': props<{timeRange: TimeRange}>(),
+    'Set selected measurement data type': props<{measurementDataType: MeasurementDataType}>(),
   },
 });

--- a/src/app/state/form/actions/form.actions.ts
+++ b/src/app/state/form/actions/form.actions.ts
@@ -7,5 +7,6 @@ export const formActions = createActionGroup({
     'Set selected parameters': props<{parameterGroupId: FormState['selectedParameterGroupId']}>(),
     'Set selected dataInterval': props<{dataInterval: FormState['selectedDataInterval']}>(),
     'Set selected time range': props<{timeRange: FormState['selectedTimeRange']}>(),
+    'Set selected measurement data type': props<{measurementDataType: FormState['selectedMeasurementDataType']}>(),
   },
 });

--- a/src/app/state/form/effects/form.effects.spec.ts
+++ b/src/app/state/form/effects/form.effects.spec.ts
@@ -1,0 +1,38 @@
+import {TestBed} from '@angular/core/testing';
+import {Action} from '@ngrx/store';
+import {MockStore, provideMockStore} from '@ngrx/store/testing';
+import {Observable, of} from 'rxjs';
+import {collectionConfig} from '../../../shared/configs/collections.config';
+import {collectionActions} from '../../collection/actions/collection.action';
+import {formActions} from '../actions/form.actions';
+import {loadCollectionsForSelectedMeasurementDataType} from './form.effects';
+
+describe('FormEffects', () => {
+  const measurementDataType = collectionConfig.defaultMeasurementDataType;
+
+  let actions$: Observable<Action>;
+  let store: MockStore;
+
+  beforeEach(() => {
+    actions$ = new Observable<Action>();
+    TestBed.configureTestingModule({
+      providers: [provideMockStore()],
+    });
+    store = TestBed.inject(MockStore);
+  });
+
+  afterEach(() => {
+    store.resetSelectors();
+  });
+
+  it('should dispatch loadCollection action when setSelectedMeasurementDataType is dispatched', (done: DoneFn) => {
+    actions$ = of(formActions.setSelectedMeasurementDataType({measurementDataType}));
+
+    loadCollectionsForSelectedMeasurementDataType(actions$).subscribe((action) => {
+      expect(action).toEqual(
+        collectionActions.loadCollections({collections: collectionConfig.collections[measurementDataType], measurementDataType}),
+      );
+      done();
+    });
+  });
+});

--- a/src/app/state/form/effects/form.effects.ts
+++ b/src/app/state/form/effects/form.effects.ts
@@ -1,0 +1,18 @@
+import {inject} from '@angular/core';
+import {Actions, createEffect, ofType} from '@ngrx/effects';
+import {map} from 'rxjs';
+import {collectionConfig} from '../../../shared/configs/collections.config';
+import {collectionActions} from '../../collection/actions/collection.action';
+import {formActions} from '../actions/form.actions';
+
+export const updateCollectionsForMeasurementDataType = createEffect(
+  (actions$ = inject(Actions)) => {
+    return actions$.pipe(
+      ofType(formActions.setSelectedMeasurementDataType),
+      map(({measurementDataType}) =>
+        collectionActions.loadCollections({measurementDataType, collections: collectionConfig.collections[measurementDataType]}),
+      ),
+    );
+  },
+  {functional: true},
+);

--- a/src/app/state/form/effects/form.effects.ts
+++ b/src/app/state/form/effects/form.effects.ts
@@ -5,7 +5,7 @@ import {collectionConfig} from '../../../shared/configs/collections.config';
 import {collectionActions} from '../../collection/actions/collection.action';
 import {formActions} from '../actions/form.actions';
 
-export const updateCollectionsForMeasurementDataType = createEffect(
+export const loadCollectionsForSelectedMeasurementDataType = createEffect(
   (actions$ = inject(Actions)) => {
     return actions$.pipe(
       ofType(formActions.setSelectedMeasurementDataType),

--- a/src/app/state/form/reducers/form.reducer.spec.ts
+++ b/src/app/state/form/reducers/form.reducer.spec.ts
@@ -28,4 +28,12 @@ describe('Parameter Reducer', () => {
     expect(result.selectedDataInterval).toBe('monthly');
     expect(result.selectedTimeRange).toBe(null);
   });
+
+  it('should reset the form state when a measurement data type is selected', () => {
+    state = {...state, selectedParameterGroupId: 'A', selectedDataInterval: 'daily', selectedTimeRange: 'all-time'};
+    const action = formActions.setSelectedMeasurementDataType({measurementDataType: 'homogenous'});
+    const result = formFeature.reducer(state, action);
+
+    expect(result).toEqual({...initialState, selectedMeasurementDataType: 'homogenous'});
+  });
 });

--- a/src/app/state/form/reducers/form.reducer.spec.ts
+++ b/src/app/state/form/reducers/form.reducer.spec.ts
@@ -6,7 +6,7 @@ describe('Parameter Reducer', () => {
   let state: FormState;
 
   beforeEach(() => {
-    state = initialState;
+    state = structuredClone(initialState);
   });
 
   it('should reset selection of upcoming steps if parameter is selected', () => {

--- a/src/app/state/form/reducers/form.reducer.ts
+++ b/src/app/state/form/reducers/form.reducer.ts
@@ -1,4 +1,5 @@
 import {createFeature, createReducer, on} from '@ngrx/store';
+import {collectionConfig} from '../../../shared/configs/collections.config';
 import {formActions} from '../actions/form.actions';
 import {FormState} from '../states/form.state';
 
@@ -8,6 +9,7 @@ export const initialState: FormState = {
   selectedParameterGroupId: null,
   selectedDataInterval: null,
   selectedTimeRange: null,
+  selectedMeasurementDataType: collectionConfig.defaultMeasurementDataType,
 };
 
 export const formFeature = createFeature({
@@ -37,6 +39,10 @@ export const formFeature = createFeature({
         ...state,
         selectedTimeRange: timeRange,
       }),
+    ),
+    on(
+      formActions.setSelectedMeasurementDataType,
+      (_, {measurementDataType}): FormState => ({...initialState, selectedMeasurementDataType: measurementDataType}),
     ),
   ),
 });

--- a/src/app/state/form/states/form.state.ts
+++ b/src/app/state/form/states/form.state.ts
@@ -1,8 +1,10 @@
 import {DataInterval} from '../../../shared/models/interval';
+import {MeasurementDataType} from '../../../shared/models/measurement-data-type';
 import {TimeRange} from '../../../shared/models/time-range';
 
 export interface FormState {
   selectedParameterGroupId: string | null;
   selectedDataInterval: DataInterval | null;
   selectedTimeRange: TimeRange | null;
+  selectedMeasurementDataType: MeasurementDataType;
 }

--- a/src/app/state/index.ts
+++ b/src/app/state/index.ts
@@ -1,3 +1,4 @@
+import * as formEffects from './form/effects/form.effects';
 import {formFeature, formFeatureKey} from './form/reducers/form.reducer';
 import * as mapEffects from './map/effects/map.effects';
 import * as parameterStationMappingEffects from './parameter-station-mapping/effects/parameter-station-mapping.effects';
@@ -34,5 +35,6 @@ export const effects: (Type<unknown> | Record<string, FunctionalEffect>)[] = [
   stationEffects,
   mapEffects,
   parameterStationMappingEffects,
+  formEffects,
 ];
 export const metaReducers: MetaReducer<State>[] = [];

--- a/src/app/state/map/effects/map.effects.spec.ts
+++ b/src/app/state/map/effects/map.effects.spec.ts
@@ -3,10 +3,11 @@ import {Action} from '@ngrx/store';
 import {MockStore, provideMockStore} from '@ngrx/store/testing';
 import {Observable, of} from 'rxjs';
 import {MapService} from '../../../map/services/map.service';
+import {collectionConfig} from '../../../shared/configs/collections.config';
 import {Station} from '../../../shared/models/station';
 import {formActions} from '../../form/actions/form.actions';
 import {stationActions} from '../../stations/actions/station.action';
-import {stationFeature} from '../../stations/reducers/station.reducer';
+import {selectCurrentStationState} from '../../stations/selectors/station.selector';
 import {addStationsToMap, filterStationsOnMap} from './map.effects';
 
 describe('MapEffects', () => {
@@ -28,7 +29,7 @@ describe('MapEffects', () => {
 
   it('should add stations to the map when stationActions.setLoadedStations is dispatched', (done) => {
     const stations: Station[] = [{id: '1', name: 'Station 1', coordinates: {longitude: 0, latitude: 0}}];
-    actions$ = of(stationActions.setLoadedStations({stations}));
+    actions$ = of(stationActions.setLoadedStations({stations, measurementDataType: collectionConfig.defaultMeasurementDataType}));
     addStationsToMap(actions$, mapService).subscribe(() => {
       expect(mapService.addStationsToMap).toHaveBeenCalledOnceWith(stations);
       done();
@@ -37,7 +38,7 @@ describe('MapEffects', () => {
 
   it('should filter stations on the map when formActions.setSelectedParameters is dispatched', (done) => {
     const stations: Station[] = [{id: '1', name: 'Station 1', coordinates: {longitude: 0, latitude: 0}}];
-    store.overrideSelector(stationFeature.selectStations, stations);
+    store.overrideSelector(selectCurrentStationState, {stations, loadingState: 'loaded'});
     actions$ = of(formActions.setSelectedParameters({parameterGroupId: 'test-group-id'}));
     filterStationsOnMap(actions$, store, mapService).subscribe(() => {
       expect(mapService.filterStationsOnMap).toHaveBeenCalledOnceWith(stations);

--- a/src/app/state/map/effects/map.effects.ts
+++ b/src/app/state/map/effects/map.effects.ts
@@ -6,7 +6,7 @@ import {tap} from 'rxjs';
 import {MapService} from '../../../map/services/map.service';
 import {formActions} from '../../form/actions/form.actions';
 import {stationActions} from '../../stations/actions/station.action';
-import {stationFeature} from '../../stations/reducers/station.reducer';
+import {selectCurrentStationState} from '../../stations/selectors/station.selector';
 
 export const addStationsToMap = createEffect(
   (actions$ = inject(Actions), mapService = inject(MapService)) => {
@@ -23,8 +23,8 @@ export const filterStationsOnMap = createEffect(
     return actions$.pipe(
       ofType(formActions.setSelectedParameters),
       // TODO the following selector has to be replaced with one that returns stations filtered by the current parameter group selection
-      concatLatestFrom(() => store.select(stationFeature.selectStations)),
-      tap(([, stations]) => mapService.filterStationsOnMap(stations)),
+      concatLatestFrom(() => store.select(selectCurrentStationState)),
+      tap(([, stationState]) => mapService.filterStationsOnMap(stationState.stations)),
     );
   },
   {functional: true, dispatch: false},

--- a/src/app/state/parameter-station-mapping/actions/parameter-station-mapping.action.ts
+++ b/src/app/state/parameter-station-mapping/actions/parameter-station-mapping.action.ts
@@ -1,12 +1,15 @@
 import {createActionGroup, props} from '@ngrx/store';
+import {MeasurementDataType} from '../../../shared/models/measurement-data-type';
 import {ParameterStationMapping} from '../../../shared/models/parameter-station-mapping';
-import {errorProps} from '../../utils/error-props.util';
 
 export const parameterStationMappingActions = createActionGroup({
   source: 'ParameterStationMappings',
   events: {
-    'Set loaded parameter station mappings': props<{parameterStationMappings: ParameterStationMapping[]}>(),
-    'Load parameter station mappings for collections': props<{collections: string[]}>(),
-    'Set parameter station mapping loading error': errorProps(),
+    'Set loaded parameter station mappings': props<{
+      parameterStationMappings: ParameterStationMapping[];
+      measurementDataType: MeasurementDataType;
+    }>(),
+    'Load parameter station mappings for collections': props<{collections: string[]; measurementDataType: MeasurementDataType}>(),
+    'Set parameter station mapping loading error': props<{error?: unknown; measurementDataType: MeasurementDataType}>(),
   },
 });

--- a/src/app/state/parameter-station-mapping/effects/parameter-station-mapping.effects.spec.ts
+++ b/src/app/state/parameter-station-mapping/effects/parameter-station-mapping.effects.spec.ts
@@ -8,7 +8,7 @@ import {OpendataExplorerRuntimeErrorTestUtil} from '../../../shared/testing/util
 import {DataInventoryService} from '../../../stac/service/data-inventory.service';
 import {collectionActions} from '../../collection/actions/collection.action';
 import {parameterStationMappingActions} from '../actions/parameter-station-mapping.action';
-import {parameterStationMappingFeature} from '../reducers/parameter-station-mapping.reducer';
+import {selectCurrentParameterStationMappingState} from '../selectors/parameter-group-station-mapping.selector';
 import {
   failLoadingCollectionParameterStationMappings,
   loadCollectionParameterStationMappings,
@@ -39,25 +39,32 @@ describe('ParameterStationMappingEffects', () => {
     const collections = ['collection'];
     actions$ = of(collectionActions.loadCollections({collections, measurementDataType}));
     loadCollectionParameterStationMappings(actions$).subscribe((action) => {
-      expect(action).toEqual(parameterStationMappingActions.loadParameterStationMappingsForCollections({collections}));
+      expect(action).toEqual(parameterStationMappingActions.loadParameterStationMappingsForCollections({collections, measurementDataType}));
       done();
     });
   });
 
   it('should dispatch the SetParameterStationMapping action when loading parameterStationMappings for collections', (done: DoneFn) => {
     spyOn(dataInventoryService, 'loadParameterStationMappingsForCollections').and.resolveTo([]);
-    actions$ = of(parameterStationMappingActions.loadParameterStationMappingsForCollections({collections: ['collection']}));
+    store.overrideSelector(selectCurrentParameterStationMappingState, {parameterStationMappings: [], loadingState: undefined});
+    actions$ = of(
+      parameterStationMappingActions.loadParameterStationMappingsForCollections({collections: ['collection'], measurementDataType}),
+    );
 
     loadParameterStationMappings(actions$, store, dataInventoryService).subscribe((action) => {
-      expect(action).toEqual(parameterStationMappingActions.setLoadedParameterStationMappings({parameterStationMappings: []}));
+      expect(action).toEqual(
+        parameterStationMappingActions.setLoadedParameterStationMappings({parameterStationMappings: [], measurementDataType}),
+      );
       done();
     });
   });
 
   it('should not call the service if the data is already loaded', (done: DoneFn) => {
     spyOn(dataInventoryService, 'loadParameterStationMappingsForCollections');
-    store.overrideSelector(parameterStationMappingFeature.selectLoadingState, 'loaded');
-    actions$ = of(parameterStationMappingActions.loadParameterStationMappingsForCollections({collections: ['collection']}));
+    store.overrideSelector(selectCurrentParameterStationMappingState, {parameterStationMappings: [], loadingState: 'loaded'});
+    actions$ = of(
+      parameterStationMappingActions.loadParameterStationMappingsForCollections({collections: ['collection'], measurementDataType}),
+    );
 
     loadParameterStationMappings(actions$, store, dataInventoryService).subscribe({
       complete: () => {
@@ -71,7 +78,7 @@ describe('ParameterStationMappingEffects', () => {
     const error = new Error('My cabbages!!!');
     const expectedError = new ParameterStationMappingError(error);
 
-    actions$ = of(parameterStationMappingActions.setParameterStationMappingLoadingError({error}));
+    actions$ = of(parameterStationMappingActions.setParameterStationMappingLoadingError({error, measurementDataType}));
     failLoadingCollectionParameterStationMappings(actions$)
       .pipe(
         catchError((caughtError: unknown) => {
@@ -85,11 +92,14 @@ describe('ParameterStationMappingEffects', () => {
 
   it('should set loading error if the service throws an error', (done: DoneFn) => {
     const error = new Error('test');
+    store.overrideSelector(selectCurrentParameterStationMappingState, {parameterStationMappings: [], loadingState: undefined});
     spyOn(dataInventoryService, 'loadParameterStationMappingsForCollections').and.rejectWith(error);
-    actions$ = of(parameterStationMappingActions.loadParameterStationMappingsForCollections({collections: ['collection']}));
+    actions$ = of(
+      parameterStationMappingActions.loadParameterStationMappingsForCollections({collections: ['collection'], measurementDataType}),
+    );
 
     loadParameterStationMappings(actions$, store, dataInventoryService).subscribe((action) => {
-      expect(action).toEqual(parameterStationMappingActions.setParameterStationMappingLoadingError({error}));
+      expect(action).toEqual(parameterStationMappingActions.setParameterStationMappingLoadingError({error, measurementDataType}));
       done();
     });
   });

--- a/src/app/state/parameter-station-mapping/effects/parameter-station-mapping.effects.spec.ts
+++ b/src/app/state/parameter-station-mapping/effects/parameter-station-mapping.effects.spec.ts
@@ -2,6 +2,7 @@ import {TestBed} from '@angular/core/testing';
 import {Action} from '@ngrx/store';
 import {MockStore, provideMockStore} from '@ngrx/store/testing';
 import {catchError, EMPTY, Observable, of} from 'rxjs';
+import {collectionConfig} from '../../../shared/configs/collections.config';
 import {ParameterStationMappingError} from '../../../shared/errors/parameter-station-mapping.error';
 import {OpendataExplorerRuntimeErrorTestUtil} from '../../../shared/testing/utils/opendata-explorer-runtime-error-test.util';
 import {DataInventoryService} from '../../../stac/service/data-inventory.service';
@@ -15,6 +16,8 @@ import {
 } from './parameter-station-mapping.effects';
 
 describe('ParameterStationMappingEffects', () => {
+  const measurementDataType = collectionConfig.defaultMeasurementDataType;
+
   let actions$: Observable<Action>;
   let store: MockStore;
   let dataInventoryService: DataInventoryService;
@@ -34,7 +37,7 @@ describe('ParameterStationMappingEffects', () => {
 
   it('should dispatch loadParameterStationMapping action when loadCollection is dispatched', (done: DoneFn) => {
     const collections = ['collection'];
-    actions$ = of(collectionActions.loadCollections({collections}));
+    actions$ = of(collectionActions.loadCollections({collections, measurementDataType}));
     loadCollectionParameterStationMappings(actions$).subscribe((action) => {
       expect(action).toEqual(parameterStationMappingActions.loadParameterStationMappingsForCollections({collections}));
       done();

--- a/src/app/state/parameter-station-mapping/effects/parameter-station-mapping.effects.ts
+++ b/src/app/state/parameter-station-mapping/effects/parameter-station-mapping.effects.ts
@@ -13,7 +13,7 @@ export const loadCollectionParameterStationMappings = createEffect(
   (actions$ = inject(Actions)) => {
     return actions$.pipe(
       ofType(collectionActions.loadCollections),
-      map(({collections}) => parameterStationMappingActions.loadParameterStationMappingsForCollections({collections})),
+      map(({measurementDataType, collections}) => parameterStationMappingActions.loadParameterStationMappingsForCollections({collections})),
     );
   },
   {functional: true},

--- a/src/app/state/parameter-station-mapping/effects/parameter-station-mapping.effects.ts
+++ b/src/app/state/parameter-station-mapping/effects/parameter-station-mapping.effects.ts
@@ -7,13 +7,15 @@ import {ParameterStationMappingError} from '../../../shared/errors/parameter-sta
 import {DataInventoryService} from '../../../stac/service/data-inventory.service';
 import {collectionActions} from '../../collection/actions/collection.action';
 import {parameterStationMappingActions} from '../actions/parameter-station-mapping.action';
-import {parameterStationMappingFeature} from '../reducers/parameter-station-mapping.reducer';
+import {selectCurrentParameterStationMappingState} from '../selectors/parameter-group-station-mapping.selector';
 
 export const loadCollectionParameterStationMappings = createEffect(
   (actions$ = inject(Actions)) => {
     return actions$.pipe(
       ofType(collectionActions.loadCollections),
-      map(({measurementDataType, collections}) => parameterStationMappingActions.loadParameterStationMappingsForCollections({collections})),
+      map(({measurementDataType, collections}) =>
+        parameterStationMappingActions.loadParameterStationMappingsForCollections({collections, measurementDataType}),
+      ),
     );
   },
   {functional: true},
@@ -23,12 +25,16 @@ export const loadParameterStationMappings = createEffect(
   (actions$ = inject(Actions), store = inject(Store), dataInventoryService = inject(DataInventoryService)) => {
     return actions$.pipe(
       ofType(parameterStationMappingActions.loadParameterStationMappingsForCollections),
-      concatLatestFrom(() => store.select(parameterStationMappingFeature.selectLoadingState)),
-      filter(([_, loadingState]) => loadingState !== 'loaded'),
-      switchMap(([{collections}]) =>
+      concatLatestFrom(() => store.select(selectCurrentParameterStationMappingState)),
+      filter(([_, parameterStationMappingState]) => parameterStationMappingState.loadingState !== 'loaded'),
+      switchMap(([{collections, measurementDataType}]) =>
         from(dataInventoryService.loadParameterStationMappingsForCollections(collections)).pipe(
-          map((parameterStationMappings) => parameterStationMappingActions.setLoadedParameterStationMappings({parameterStationMappings})),
-          catchError((error: unknown) => of(parameterStationMappingActions.setParameterStationMappingLoadingError({error}))),
+          map((parameterStationMappings) =>
+            parameterStationMappingActions.setLoadedParameterStationMappings({parameterStationMappings, measurementDataType}),
+          ),
+          catchError((error: unknown) =>
+            of(parameterStationMappingActions.setParameterStationMappingLoadingError({error, measurementDataType})),
+          ),
         ),
       ),
     );

--- a/src/app/state/parameter-station-mapping/reducers/parameter-station-mapping.reducer.spec.ts
+++ b/src/app/state/parameter-station-mapping/reducers/parameter-station-mapping.reducer.spec.ts
@@ -1,4 +1,3 @@
-import {produce} from 'immer';
 import {collectionConfig} from '../../../shared/configs/collections.config';
 import {ParameterStationMapping} from '../../../shared/models/parameter-station-mapping';
 import {parameterStationMappingActions} from '../actions/parameter-station-mapping.action';
@@ -11,14 +10,13 @@ describe('ParameterStationMapping Reducer', () => {
   let state: ParameterStationMappingState;
 
   beforeEach(() => {
-    state = initialState;
+    state = structuredClone(initialState);
   });
 
   it('should set loadingState to loading when loadParameterStationMappingForCollections is dispatched and loading state is currently not loaded', () => {
-    state = produce(state, (draft) => {
-      draft[measurementDataType].loadingState = 'error';
-    });
+    state[measurementDataType].loadingState = 'error';
     const action = parameterStationMappingActions.loadParameterStationMappingsForCollections({collections: ['test'], measurementDataType});
+
     const result = parameterStationMappingFeature.reducer(state, action);
 
     expect(result[measurementDataType].loadingState).toBe('loading');
@@ -26,10 +24,9 @@ describe('ParameterStationMapping Reducer', () => {
   });
 
   it('should not change loadingState if it is already loaded when loadParameterStationMappingForCollections is dispatched', () => {
-    state = produce(state, (draft) => {
-      draft[measurementDataType].loadingState = 'loaded';
-    });
+    state[measurementDataType].loadingState = 'loaded';
     const action = parameterStationMappingActions.loadParameterStationMappingsForCollections({collections: ['test'], measurementDataType});
+
     const result = parameterStationMappingFeature.reducer(state, action);
 
     expect(result[measurementDataType].loadingState).toBe('loaded');
@@ -44,6 +41,7 @@ describe('ParameterStationMapping Reducer', () => {
       },
     ];
     const action = parameterStationMappingActions.setLoadedParameterStationMappings({parameterStationMappings, measurementDataType});
+
     const result = parameterStationMappingFeature.reducer(state, action);
 
     expect(result[measurementDataType].parameterStationMappings).toEqual(parameterStationMappings);
@@ -52,6 +50,7 @@ describe('ParameterStationMapping Reducer', () => {
 
   it('should reset to initialState and set loadingState to error when setParameterStationMappingLoadingError is dispatched', () => {
     const action = parameterStationMappingActions.setParameterStationMappingLoadingError({measurementDataType});
+
     const result = parameterStationMappingFeature.reducer(state, action);
 
     expect(result).toEqual({...initialState, [measurementDataType]: {...initialState[measurementDataType], loadingState: 'error'}});

--- a/src/app/state/parameter-station-mapping/reducers/parameter-station-mapping.reducer.spec.ts
+++ b/src/app/state/parameter-station-mapping/reducers/parameter-station-mapping.reducer.spec.ts
@@ -1,9 +1,13 @@
+import {produce} from 'immer';
+import {collectionConfig} from '../../../shared/configs/collections.config';
 import {ParameterStationMapping} from '../../../shared/models/parameter-station-mapping';
 import {parameterStationMappingActions} from '../actions/parameter-station-mapping.action';
 import {ParameterStationMappingState} from '../states/parameter-station-mapping.state';
 import {initialState, parameterStationMappingFeature} from './parameter-station-mapping.reducer';
 
 describe('ParameterStationMapping Reducer', () => {
+  const measurementDataType = collectionConfig.defaultMeasurementDataType;
+
   let state: ParameterStationMappingState;
 
   beforeEach(() => {
@@ -11,21 +15,25 @@ describe('ParameterStationMapping Reducer', () => {
   });
 
   it('should set loadingState to loading when loadParameterStationMappingForCollections is dispatched and loading state is currently not loaded', () => {
-    state = {...state, loadingState: 'error'};
-    const action = parameterStationMappingActions.loadParameterStationMappingsForCollections({collections: ['test']});
+    state = produce(state, (draft) => {
+      draft[measurementDataType].loadingState = 'error';
+    });
+    const action = parameterStationMappingActions.loadParameterStationMappingsForCollections({collections: ['test'], measurementDataType});
     const result = parameterStationMappingFeature.reducer(state, action);
 
-    expect(result.loadingState).toBe('loading');
-    expect(result.parameterStationMappings).toEqual([]);
+    expect(result[measurementDataType].loadingState).toBe('loading');
+    expect(result[measurementDataType].parameterStationMappings).toEqual([]);
   });
 
   it('should not change loadingState if it is already loaded when loadParameterStationMappingForCollections is dispatched', () => {
-    state = {...state, loadingState: 'loaded'};
-    const action = parameterStationMappingActions.loadParameterStationMappingsForCollections({collections: ['test']});
+    state = produce(state, (draft) => {
+      draft[measurementDataType].loadingState = 'loaded';
+    });
+    const action = parameterStationMappingActions.loadParameterStationMappingsForCollections({collections: ['test'], measurementDataType});
     const result = parameterStationMappingFeature.reducer(state, action);
 
-    expect(result.loadingState).toBe('loaded');
-    expect(result.parameterStationMappings).toEqual([]);
+    expect(result[measurementDataType].loadingState).toBe('loaded');
+    expect(result[measurementDataType].parameterStationMappings).toEqual([]);
   });
 
   it('should set parameterStationMappings and loadingState to loaded when setLoadedParameterStationMappings is dispatched', () => {
@@ -35,17 +43,17 @@ describe('ParameterStationMapping Reducer', () => {
         stationId: 'test-station-id',
       },
     ];
-    const action = parameterStationMappingActions.setLoadedParameterStationMappings({parameterStationMappings});
+    const action = parameterStationMappingActions.setLoadedParameterStationMappings({parameterStationMappings, measurementDataType});
     const result = parameterStationMappingFeature.reducer(state, action);
 
-    expect(result.parameterStationMappings).toEqual(parameterStationMappings);
-    expect(result.loadingState).toBe('loaded');
+    expect(result[measurementDataType].parameterStationMappings).toEqual(parameterStationMappings);
+    expect(result[measurementDataType].loadingState).toBe('loaded');
   });
 
   it('should reset to initialState and set loadingState to error when setParameterStationMappingLoadingError is dispatched', () => {
-    const action = parameterStationMappingActions.setParameterStationMappingLoadingError({});
+    const action = parameterStationMappingActions.setParameterStationMappingLoadingError({measurementDataType});
     const result = parameterStationMappingFeature.reducer(state, action);
 
-    expect(result).toEqual({...initialState, loadingState: 'error'});
+    expect(result).toEqual({...initialState, [measurementDataType]: {...initialState[measurementDataType], loadingState: 'error'}});
   });
 });

--- a/src/app/state/parameter-station-mapping/reducers/parameter-station-mapping.reducer.ts
+++ b/src/app/state/parameter-station-mapping/reducers/parameter-station-mapping.reducer.ts
@@ -1,13 +1,19 @@
 import {createFeature, createReducer, on} from '@ngrx/store';
+import {produce} from 'immer';
+import {measurementDataTypes} from '../../../shared/models/measurement-data-type';
 import {parameterStationMappingActions} from '../actions/parameter-station-mapping.action';
-import {ParameterStationMappingState} from '../states/parameter-station-mapping.state';
+import {ParameterStationMappingState, ParameterStationMappingStateEntry} from '../states/parameter-station-mapping.state';
 
 export const parameterStationMappingFeatureKey = 'parameterStationMappings';
 
-export const initialState: ParameterStationMappingState = {
+export const initialEntryState: ParameterStationMappingStateEntry = {
   parameterStationMappings: [],
   loadingState: undefined,
 };
+
+export const initialState: ParameterStationMappingState = Object.fromEntries(
+  measurementDataTypes.map((k) => [k, initialEntryState]),
+) as ParameterStationMappingState;
 
 export const parameterStationMappingFeature = createFeature({
   name: parameterStationMappingFeatureKey,
@@ -15,21 +21,24 @@ export const parameterStationMappingFeature = createFeature({
     initialState,
     on(
       parameterStationMappingActions.loadParameterStationMappingsForCollections,
-      (state): ParameterStationMappingState => ({
-        ...state,
-        loadingState: state.loadingState !== 'loaded' ? 'loading' : state.loadingState,
+      produce((draft, {measurementDataType}) => {
+        const state = draft[measurementDataType];
+        state.loadingState = state.loadingState !== 'loaded' ? 'loading' : state.loadingState;
       }),
     ),
     on(
       parameterStationMappingActions.setLoadedParameterStationMappings,
-      (state, {parameterStationMappings}): ParameterStationMappingState => ({
-        ...state,
-        parameterStationMappings,
-        loadingState: 'loaded',
+      produce((draft, {measurementDataType, parameterStationMappings}) => {
+        const state = draft[measurementDataType];
+        state.parameterStationMappings = parameterStationMappings;
+        state.loadingState = 'loaded';
       }),
     ),
-    on(parameterStationMappingActions.setParameterStationMappingLoadingError, (): ParameterStationMappingState => {
-      return {...initialState, loadingState: 'error'};
-    }),
+    on(
+      parameterStationMappingActions.setParameterStationMappingLoadingError,
+      produce((draft, {measurementDataType}) => {
+        draft[measurementDataType] = {...initialEntryState, loadingState: 'error'};
+      }),
+    ),
   ),
 });

--- a/src/app/state/parameter-station-mapping/reducers/parameter-station-mapping.reducer.ts
+++ b/src/app/state/parameter-station-mapping/reducers/parameter-station-mapping.reducer.ts
@@ -1,6 +1,5 @@
 import {createFeature, createReducer, on} from '@ngrx/store';
 import {produce} from 'immer';
-import {measurementDataTypes} from '../../../shared/models/measurement-data-type';
 import {parameterStationMappingActions} from '../actions/parameter-station-mapping.action';
 import {ParameterStationMappingState, ParameterStationMappingStateEntry} from '../states/parameter-station-mapping.state';
 
@@ -11,9 +10,10 @@ export const initialEntryState: ParameterStationMappingStateEntry = {
   loadingState: undefined,
 };
 
-export const initialState: ParameterStationMappingState = Object.fromEntries(
-  measurementDataTypes.map((k) => [k, initialEntryState]),
-) as ParameterStationMappingState;
+export const initialState: ParameterStationMappingState = {
+  homogenous: {...initialEntryState},
+  normal: {...initialEntryState},
+};
 
 export const parameterStationMappingFeature = createFeature({
   name: parameterStationMappingFeatureKey,

--- a/src/app/state/parameter-station-mapping/selectors/parameter-group-station-mapping.selector.spec.ts
+++ b/src/app/state/parameter-station-mapping/selectors/parameter-group-station-mapping.selector.spec.ts
@@ -36,7 +36,7 @@ describe('ParameterGroupStationMapping Selectors', () => {
         {parameterId: 'nonExistingParam', stationId: 'stationId1'},
       ];
 
-      const result = selectParameterGroupStationMappings.projector(parameterStationMappings, parameters);
+      const result = selectParameterGroupStationMappings.projector(parameterStationMappings, {parameters, loadingState: 'loaded'});
 
       expect(result).toEqual(
         jasmine.arrayWithExactContents([
@@ -50,7 +50,7 @@ describe('ParameterGroupStationMapping Selectors', () => {
       const parameterStationMappings: ParameterStationMapping[] = [];
       const parameters: Parameter[] = [parameterOne];
 
-      const result = selectParameterGroupStationMappings.projector(parameterStationMappings, parameters);
+      const result = selectParameterGroupStationMappings.projector(parameterStationMappings, {parameters, loadingState: 'loaded'});
 
       expect(result).toEqual([]);
     });
@@ -59,7 +59,7 @@ describe('ParameterGroupStationMapping Selectors', () => {
       const parameterStationMappings: ParameterStationMapping[] = [{parameterId: 'nonExistingParam', stationId: 'stationId1'}];
       const parameters: Parameter[] = [];
 
-      const result = selectParameterGroupStationMappings.projector(parameterStationMappings, parameters);
+      const result = selectParameterGroupStationMappings.projector(parameterStationMappings, {parameters, loadingState: 'loaded'});
 
       expect(result).toEqual([]);
     });

--- a/src/app/state/parameter-station-mapping/selectors/parameter-group-station-mapping.selector.spec.ts
+++ b/src/app/state/parameter-station-mapping/selectors/parameter-group-station-mapping.selector.spec.ts
@@ -36,7 +36,10 @@ describe('ParameterGroupStationMapping Selectors', () => {
         {parameterId: 'nonExistingParam', stationId: 'stationId1'},
       ];
 
-      const result = selectParameterGroupStationMappings.projector(parameterStationMappings, {parameters, loadingState: 'loaded'});
+      const result = selectParameterGroupStationMappings.projector(
+        {parameterStationMappings, loadingState: 'loaded'},
+        {parameters, loadingState: 'loaded'},
+      );
 
       expect(result).toEqual(
         jasmine.arrayWithExactContents([
@@ -50,7 +53,10 @@ describe('ParameterGroupStationMapping Selectors', () => {
       const parameterStationMappings: ParameterStationMapping[] = [];
       const parameters: Parameter[] = [parameterOne];
 
-      const result = selectParameterGroupStationMappings.projector(parameterStationMappings, {parameters, loadingState: 'loaded'});
+      const result = selectParameterGroupStationMappings.projector(
+        {parameterStationMappings, loadingState: 'loaded'},
+        {parameters, loadingState: 'loaded'},
+      );
 
       expect(result).toEqual([]);
     });
@@ -59,7 +65,10 @@ describe('ParameterGroupStationMapping Selectors', () => {
       const parameterStationMappings: ParameterStationMapping[] = [{parameterId: 'nonExistingParam', stationId: 'stationId1'}];
       const parameters: Parameter[] = [];
 
-      const result = selectParameterGroupStationMappings.projector(parameterStationMappings, {parameters, loadingState: 'loaded'});
+      const result = selectParameterGroupStationMappings.projector(
+        {parameterStationMappings, loadingState: 'loaded'},
+        {parameters, loadingState: 'loaded'},
+      );
 
       expect(result).toEqual([]);
     });

--- a/src/app/state/parameter-station-mapping/selectors/parameter-group-station-mapping.selector.ts
+++ b/src/app/state/parameter-station-mapping/selectors/parameter-group-station-mapping.selector.ts
@@ -1,14 +1,23 @@
 import {createSelector} from '@ngrx/store';
 import {ParameterGroupStationMapping} from '../../../shared/models/parameter-group-station-mapping';
 import {ParameterService} from '../../../stac/service/parameter.service';
+import {formFeature} from '../../form/reducers/form.reducer';
 import {selectCurrentParameterState} from '../../parameters/selectors/parameter.selector';
 import {parameterStationMappingFeature} from '../reducers/parameter-station-mapping.reducer';
+import {ParameterStationMappingStateEntry} from '../states/parameter-station-mapping.state';
+
+export const selectCurrentParameterStationMappingState = createSelector(
+  parameterStationMappingFeature.selectParameterStationMappingsState,
+  formFeature.selectSelectedMeasurementDataType,
+  (parameterStationMappingState, measurementDataType): ParameterStationMappingStateEntry =>
+    parameterStationMappingState[measurementDataType],
+);
 
 export const selectParameterGroupStationMappings = createSelector(
-  parameterStationMappingFeature.selectParameterStationMappings,
+  selectCurrentParameterStationMappingState,
   selectCurrentParameterState,
-  (parameterStationMappings, parameterState): ParameterGroupStationMapping[] =>
-    parameterStationMappings.reduce((uniqueGroupMappings: ParameterGroupStationMapping[], mapping) => {
+  (parameterStationMappingState, parameterState): ParameterGroupStationMapping[] =>
+    parameterStationMappingState.parameterStationMappings.reduce((uniqueGroupMappings: ParameterGroupStationMapping[], mapping) => {
       const parameterGroup = parameterState.parameters.find((parameter) => parameter.id === mapping.parameterId)?.group;
       if (parameterGroup) {
         const parameterGroupId = ParameterService.extractGroupIdFromGroupName(parameterGroup);

--- a/src/app/state/parameter-station-mapping/selectors/parameter-group-station-mapping.selector.ts
+++ b/src/app/state/parameter-station-mapping/selectors/parameter-group-station-mapping.selector.ts
@@ -1,15 +1,15 @@
 import {createSelector} from '@ngrx/store';
 import {ParameterGroupStationMapping} from '../../../shared/models/parameter-group-station-mapping';
 import {ParameterService} from '../../../stac/service/parameter.service';
-import {parameterFeature} from '../../parameters/reducers/parameter.reducer';
+import {selectCurrentParameterState} from '../../parameters/selectors/parameter.selector';
 import {parameterStationMappingFeature} from '../reducers/parameter-station-mapping.reducer';
 
 export const selectParameterGroupStationMappings = createSelector(
   parameterStationMappingFeature.selectParameterStationMappings,
-  parameterFeature.selectParameters,
-  (parameterStationMappings, parameters): ParameterGroupStationMapping[] =>
+  selectCurrentParameterState,
+  (parameterStationMappings, parameterState): ParameterGroupStationMapping[] =>
     parameterStationMappings.reduce((uniqueGroupMappings: ParameterGroupStationMapping[], mapping) => {
-      const parameterGroup = parameters.find((parameter) => parameter.id === mapping.parameterId)?.group;
+      const parameterGroup = parameterState.parameters.find((parameter) => parameter.id === mapping.parameterId)?.group;
       if (parameterGroup) {
         const parameterGroupId = ParameterService.extractGroupIdFromGroupName(parameterGroup);
         const mappingExists = uniqueGroupMappings.some(

--- a/src/app/state/parameter-station-mapping/states/parameter-station-mapping.state.ts
+++ b/src/app/state/parameter-station-mapping/states/parameter-station-mapping.state.ts
@@ -1,6 +1,9 @@
 import {LoadableState} from '../../../shared/models/loadable-state';
+import {MeasurementDataType} from '../../../shared/models/measurement-data-type';
 import {ParameterStationMapping} from '../../../shared/models/parameter-station-mapping';
 
-export interface ParameterStationMappingState extends LoadableState {
+export interface ParameterStationMappingStateEntry extends LoadableState {
   parameterStationMappings: ParameterStationMapping[];
 }
+
+export type ParameterStationMappingState = Record<MeasurementDataType, ParameterStationMappingStateEntry>;

--- a/src/app/state/parameters/actions/parameter.action.ts
+++ b/src/app/state/parameters/actions/parameter.action.ts
@@ -1,12 +1,12 @@
 import {createActionGroup, props} from '@ngrx/store';
-import {errorProps} from '../../utils/error-props.util';
+import {MeasurementDataType} from '../../../shared/models/measurement-data-type';
 import type {Parameter} from '../../../shared/models/parameter';
 
 export const parameterActions = createActionGroup({
   source: 'Parameters',
   events: {
-    'Set loaded parameters': props<{parameters: Parameter[]}>(),
-    'Load parameters for collections': props<{collections: string[]}>(),
-    'Set parameter loading error': errorProps(),
+    'Set loaded parameters': props<{parameters: Parameter[]; measurementDataType: MeasurementDataType}>(),
+    'Load parameters for collections': props<{collections: string[]; measurementDataType: MeasurementDataType}>(),
+    'Set parameter loading error': props<{error?: unknown; measurementDataType: MeasurementDataType}>(),
   },
 });

--- a/src/app/state/parameters/effects/parameter.effects.spec.ts
+++ b/src/app/state/parameters/effects/parameter.effects.spec.ts
@@ -30,7 +30,7 @@ describe('ParameterEffects', () => {
 
   it('should dispatch loadParameter action when loadCollection is dispatched', (done: DoneFn) => {
     const collections = ['collection'];
-    actions$ = of(collectionActions.loadCollections({collections}));
+    actions$ = of(collectionActions.loadCollections({collections, measurementDataType}));
     loadCollectionParameters(actions$).subscribe((action) => {
       expect(action).toEqual(parameterActions.loadParametersForCollections({collections}));
       done();

--- a/src/app/state/parameters/effects/parameter.effects.ts
+++ b/src/app/state/parameters/effects/parameter.effects.ts
@@ -13,7 +13,7 @@ export const loadCollectionParameters = createEffect(
   (actions$ = inject(Actions)) => {
     return actions$.pipe(
       ofType(collectionActions.loadCollections),
-      map(({collections}) => parameterActions.loadParametersForCollections({collections})),
+      map(({measurementDataType, collections}) => parameterActions.loadParametersForCollections({collections})),
     );
   },
   {functional: true},

--- a/src/app/state/parameters/reducers/parameter.reducer.spec.ts
+++ b/src/app/state/parameters/reducers/parameter.reducer.spec.ts
@@ -1,4 +1,3 @@
-import {produce} from 'immer';
 import {collectionConfig} from '../../../shared/configs/collections.config';
 import {measurementDataTypes} from '../../../shared/models/measurement-data-type';
 import {Parameter} from '../../../shared/models/parameter';
@@ -18,7 +17,7 @@ describe('Parameter Reducer', () => {
   ];
 
   beforeEach(() => {
-    state = initialState;
+    state = structuredClone(initialState);
   });
 
   it('should not affect other measurement types', () => {
@@ -28,6 +27,7 @@ describe('Parameter Reducer', () => {
       return;
     }
     const action = parameterActions.setLoadedParameters({parameters, measurementDataType});
+
     const result = parameterFeature.reducer(state, action);
 
     expect(result[otherMeasurementDataType].parameters).toEqual(initialState[otherMeasurementDataType].parameters);
@@ -35,10 +35,9 @@ describe('Parameter Reducer', () => {
   });
 
   it('should set loadingState to loading when loadParameterForCollections is dispatched and loading state is currently not loaded', () => {
-    state = produce(state, (draft) => {
-      draft[measurementDataType].loadingState = 'error';
-    });
+    state[measurementDataType].loadingState = 'error';
     const action = parameterActions.loadParametersForCollections({collections: ['test'], measurementDataType});
+
     const result = parameterFeature.reducer(state, action);
 
     expect(result[measurementDataType].loadingState).toBe('loading');
@@ -46,10 +45,9 @@ describe('Parameter Reducer', () => {
   });
 
   it('should not change loadingState if it is already loaded when loadParameterForCollections is dispatched', () => {
-    state = produce(state, (draft) => {
-      draft[measurementDataType].loadingState = 'loaded';
-    });
+    state[measurementDataType].loadingState = 'loaded';
     const action = parameterActions.loadParametersForCollections({collections: ['test'], measurementDataType});
+
     const result = parameterFeature.reducer(state, action);
 
     expect(result[measurementDataType].loadingState).toBe('loaded');
@@ -58,6 +56,7 @@ describe('Parameter Reducer', () => {
 
   it('should set parameters and loadingState to loaded when setLoadedParameters is dispatched', () => {
     const action = parameterActions.setLoadedParameters({parameters, measurementDataType});
+
     const result = parameterFeature.reducer(state, action);
 
     expect(result[measurementDataType].parameters).toEqual(parameters);
@@ -66,6 +65,7 @@ describe('Parameter Reducer', () => {
 
   it('should reset to initialState and set loadingState to error when setParameterLoadingError is dispatched', () => {
     const action = parameterActions.setParameterLoadingError({measurementDataType});
+
     const result = parameterFeature.reducer(state, action);
 
     expect(result).toEqual({

--- a/src/app/state/parameters/reducers/parameter.reducer.spec.ts
+++ b/src/app/state/parameters/reducers/parameter.reducer.spec.ts
@@ -1,3 +1,6 @@
+import {produce} from 'immer';
+import {collectionConfig} from '../../../shared/configs/collections.config';
+import {measurementDataTypes} from '../../../shared/models/measurement-data-type';
 import {Parameter} from '../../../shared/models/parameter';
 import {parameterActions} from '../actions/parameter.action';
 import {ParameterState} from '../states/parameter.state';
@@ -5,48 +8,69 @@ import {initialState, parameterFeature} from './parameter.reducer';
 
 describe('Parameter Reducer', () => {
   let state: ParameterState;
+  const measurementDataType = collectionConfig.defaultMeasurementDataType;
+  const parameters: Parameter[] = [
+    {
+      id: 'test-parameter-id',
+      description: {de: 'test-description', en: 'test-description', fr: 'test-description', it: 'test-description'},
+      group: {de: 'test-group', en: 'test-group', fr: 'test-group', it: 'test-group'},
+    },
+  ];
 
   beforeEach(() => {
     state = initialState;
   });
 
-  it('should set loadingState to loading when loadParameterForCollections is dispatched and loading state is currently not loaded', () => {
-    state = {...state, loadingState: 'error'};
-    const action = parameterActions.loadParametersForCollections({collections: ['test']});
+  it('should not affect other measurement types', () => {
+    const otherMeasurementDataType = measurementDataTypes.find((dataType) => dataType !== measurementDataType);
+    if (!otherMeasurementDataType) {
+      fail('There is no other measurement data type defined. Test does not work');
+      return;
+    }
+    const action = parameterActions.setLoadedParameters({parameters, measurementDataType});
     const result = parameterFeature.reducer(state, action);
 
-    expect(result.loadingState).toBe('loading');
-    expect(result.parameters).toEqual([]);
+    expect(result[otherMeasurementDataType].parameters).toEqual(initialState[otherMeasurementDataType].parameters);
+    expect(result[otherMeasurementDataType].loadingState).toBe(initialState[otherMeasurementDataType].loadingState);
+  });
+
+  it('should set loadingState to loading when loadParameterForCollections is dispatched and loading state is currently not loaded', () => {
+    state = produce(state, (draft) => {
+      draft[measurementDataType].loadingState = 'error';
+    });
+    const action = parameterActions.loadParametersForCollections({collections: ['test'], measurementDataType});
+    const result = parameterFeature.reducer(state, action);
+
+    expect(result[measurementDataType].loadingState).toBe('loading');
+    expect(result[measurementDataType].parameters).toEqual([]);
   });
 
   it('should not change loadingState if it is already loaded when loadParameterForCollections is dispatched', () => {
-    state = {...state, loadingState: 'loaded'};
-    const action = parameterActions.loadParametersForCollections({collections: ['test']});
+    state = produce(state, (draft) => {
+      draft[measurementDataType].loadingState = 'loaded';
+    });
+    const action = parameterActions.loadParametersForCollections({collections: ['test'], measurementDataType});
     const result = parameterFeature.reducer(state, action);
 
-    expect(result.loadingState).toBe('loaded');
-    expect(result.parameters).toEqual([]);
+    expect(result[measurementDataType].loadingState).toBe('loaded');
+    expect(result[measurementDataType].parameters).toEqual([]);
   });
 
   it('should set parameters and loadingState to loaded when setLoadedParameters is dispatched', () => {
-    const parameters: Parameter[] = [
-      {
-        id: 'test-parameter-id',
-        description: {de: 'test-description', en: 'test-description', fr: 'test-description', it: 'test-description'},
-        group: {de: 'test-group', en: 'test-group', fr: 'test-group', it: 'test-group'},
-      },
-    ];
-    const action = parameterActions.setLoadedParameters({parameters});
+    const action = parameterActions.setLoadedParameters({parameters, measurementDataType});
     const result = parameterFeature.reducer(state, action);
 
-    expect(result.parameters).toEqual(parameters);
-    expect(result.loadingState).toBe('loaded');
+    expect(result[measurementDataType].parameters).toEqual(parameters);
+    expect(result[measurementDataType].loadingState).toBe('loaded');
   });
 
   it('should reset to initialState and set loadingState to error when setParameterLoadingError is dispatched', () => {
-    const action = parameterActions.setParameterLoadingError({});
+    const action = parameterActions.setParameterLoadingError({measurementDataType});
     const result = parameterFeature.reducer(state, action);
 
-    expect(result).toEqual({...initialState, loadingState: 'error'});
+    expect(result).toEqual({
+      ...initialState,
+      [measurementDataType]: {...initialState[measurementDataType], loadingState: 'error'},
+    });
   });
 });

--- a/src/app/state/parameters/reducers/parameter.reducer.ts
+++ b/src/app/state/parameters/reducers/parameter.reducer.ts
@@ -1,6 +1,5 @@
 import {createFeature, createReducer, on} from '@ngrx/store';
 import {produce} from 'immer';
-import {measurementDataTypes} from '../../../shared/models/measurement-data-type';
 import {parameterActions} from '../actions/parameter.action';
 import type {ParameterState, ParameterStateEntry} from '../states/parameter.state';
 
@@ -11,7 +10,10 @@ const initialEntryState: ParameterStateEntry = {
   loadingState: undefined,
 };
 
-export const initialState: ParameterState = Object.fromEntries(measurementDataTypes.map((k) => [k, initialEntryState])) as ParameterState;
+export const initialState: ParameterState = {
+  homogenous: {...initialEntryState},
+  normal: {...initialEntryState},
+};
 
 export const parameterFeature = createFeature({
   name: parameterFeatureKey,

--- a/src/app/state/parameters/selectors/parameter.selector.spec.ts
+++ b/src/app/state/parameters/selectors/parameter.selector.spec.ts
@@ -1,7 +1,17 @@
-import {selectParameterGroups} from './parameter.selector';
+import {produce} from 'immer';
+import {initialState} from '../reducers/parameter.reducer';
+import {ParameterState} from '../states/parameter.state';
+import {selectCurrentParameterState, selectParameterGroups} from './parameter.selector';
 import type {Parameter} from '../../../shared/models/parameter';
 
 describe('Parameter Selectors', () => {
+  const parameters: Parameter[] = [
+    {
+      id: 'test-parameter-id',
+      description: {de: 'test-description', en: 'test-description', fr: 'test-description', it: 'test-description'},
+      group: {de: 'test-group', en: 'test-group', fr: 'test-group', it: 'test-group'},
+    },
+  ];
   describe('selectParameterGroups', () => {
     it('should extract all unique parameter groups from stored parameters', () => {
       const baseParameter: Omit<Parameter, 'group'> = {
@@ -11,7 +21,7 @@ describe('Parameter Selectors', () => {
       const groupA: Parameter['group'] = {de: 'A', en: 'A', fr: 'A', it: 'A'};
       const groupB: Parameter['group'] = {de: 'B', en: 'B', fr: 'B', it: 'B'};
       const groupC: Parameter['group'] = {de: 'C', en: 'C', fr: 'C', it: 'C'};
-      const parameters: Parameter[] = [
+      const parametersWithGroups: Parameter[] = [
         {...baseParameter, group: groupC},
         {...baseParameter, group: groupC},
         {...baseParameter, group: groupB},
@@ -19,7 +29,7 @@ describe('Parameter Selectors', () => {
         {...baseParameter, group: groupB},
         {...baseParameter, group: groupC},
       ];
-      const result = selectParameterGroups.projector(parameters);
+      const result = selectParameterGroups.projector({parameters: parametersWithGroups, loadingState: 'loaded'});
 
       expect(result).toEqual(
         jasmine.arrayWithExactContents([
@@ -31,17 +41,28 @@ describe('Parameter Selectors', () => {
     });
 
     it('should use english as the id of a group', () => {
-      const parameters: Parameter[] = [
-        {
-          id: 'test-parameter-id',
-          description: {de: 'test-description', en: 'test-description', fr: 'test-description', it: 'test-description'},
-          group: {de: 'test-group', en: 'test-group', fr: 'test-group', it: 'test-group'},
-        },
-      ];
-
-      const result = selectParameterGroups.projector(parameters);
+      const result = selectParameterGroups.projector({parameters, loadingState: 'loaded'});
 
       expect(result[0].id).toBe(parameters[0].group.en);
+    });
+  });
+
+  describe('selectCurrentParameterState', () => {
+    let state: ParameterState;
+    beforeEach(() => {
+      state = initialState;
+    });
+    it('should return the current parameter state based on the selected measurement data type', () => {
+      const measurementDataType = 'normal';
+      state = produce(state, (draft) => {
+        draft[measurementDataType].parameters = parameters;
+        draft[measurementDataType].loadingState = 'loaded';
+      });
+
+      const result = selectCurrentParameterState.projector(state, measurementDataType);
+
+      expect(result.parameters).toEqual(jasmine.arrayWithExactContents(parameters));
+      expect(result.loadingState).toBe('loaded');
     });
   });
 });

--- a/src/app/state/parameters/selectors/parameter.selector.spec.ts
+++ b/src/app/state/parameters/selectors/parameter.selector.spec.ts
@@ -1,4 +1,3 @@
-import {produce} from 'immer';
 import {initialState} from '../reducers/parameter.reducer';
 import {ParameterState} from '../states/parameter.state';
 import {selectCurrentParameterState, selectParameterGroups} from './parameter.selector';
@@ -50,14 +49,12 @@ describe('Parameter Selectors', () => {
   describe('selectCurrentParameterState', () => {
     let state: ParameterState;
     beforeEach(() => {
-      state = initialState;
+      state = structuredClone(initialState);
     });
     it('should return the current parameter state based on the selected measurement data type', () => {
       const measurementDataType = 'normal';
-      state = produce(state, (draft) => {
-        draft[measurementDataType].parameters = parameters;
-        draft[measurementDataType].loadingState = 'loaded';
-      });
+      state[measurementDataType].parameters = parameters;
+      state[measurementDataType].loadingState = 'loaded';
 
       const result = selectCurrentParameterState.projector(state, measurementDataType);
 

--- a/src/app/state/parameters/selectors/parameter.selector.ts
+++ b/src/app/state/parameters/selectors/parameter.selector.ts
@@ -1,10 +1,18 @@
 import {createSelector} from '@ngrx/store';
 import {ParameterService} from '../../../stac/service/parameter.service';
+import {formFeature} from '../../form/reducers/form.reducer';
 import {parameterFeature} from '../reducers/parameter.reducer';
 import type {ParameterGroup} from '../../../shared/models/parameter';
+import type {ParameterStateEntry} from '../states/parameter.state';
 
-export const selectParameterGroups = createSelector(parameterFeature.selectParameters, (parameters): ParameterGroup[] =>
-  parameters
+export const selectCurrentParameterState = createSelector(
+  parameterFeature.selectParametersState,
+  formFeature.selectSelectedMeasurementDataType,
+  (parameterState, measurementDataType): ParameterStateEntry => parameterState[measurementDataType],
+);
+
+export const selectParameterGroups = createSelector(selectCurrentParameterState, (parameterState): ParameterGroup[] =>
+  parameterState.parameters
     .map((parameter) => ({name: parameter.group, id: ParameterService.extractGroupIdFromGroupName(parameter.group)}))
     .reduce(
       (uniqueGroups: ParameterGroup[], group) =>

--- a/src/app/state/parameters/states/parameter.state.ts
+++ b/src/app/state/parameters/states/parameter.state.ts
@@ -1,6 +1,9 @@
 import {LoadableState} from '../../../shared/models/loadable-state';
+import {MeasurementDataType} from '../../../shared/models/measurement-data-type';
 import type {Parameter} from '../../../shared/models/parameter';
 
-export interface ParameterState extends LoadableState {
+export interface ParameterStateEntry extends LoadableState {
   parameters: Parameter[];
 }
+
+export type ParameterState = Record<MeasurementDataType, ParameterStateEntry>;

--- a/src/app/state/stations/actions/station.action.ts
+++ b/src/app/state/stations/actions/station.action.ts
@@ -1,12 +1,12 @@
 import {createActionGroup, props} from '@ngrx/store';
+import {MeasurementDataType} from '../../../shared/models/measurement-data-type';
 import {Station} from '../../../shared/models/station';
-import {errorProps} from '../../utils/error-props.util';
 
 export const stationActions = createActionGroup({
   source: 'Stations',
   events: {
-    'Set loaded stations': props<{stations: Station[]}>(),
-    'Load stations for collections': props<{collections: string[]}>(),
-    'Set station loading error': errorProps(),
+    'Set loaded stations': props<{stations: Station[]; measurementDataType: MeasurementDataType}>(),
+    'Load stations for collections': props<{collections: string[]; measurementDataType: MeasurementDataType}>(),
+    'Set station loading error': props<{error?: unknown; measurementDataType: MeasurementDataType}>(),
   },
 });

--- a/src/app/state/stations/effects/station.effects.spec.ts
+++ b/src/app/state/stations/effects/station.effects.spec.ts
@@ -2,6 +2,7 @@ import {TestBed} from '@angular/core/testing';
 import {Action} from '@ngrx/store';
 import {MockStore, provideMockStore} from '@ngrx/store/testing';
 import {catchError, EMPTY, Observable, of} from 'rxjs';
+import {collectionConfig} from '../../../shared/configs/collections.config';
 import {StationError} from '../../../shared/errors/station.error';
 import {OpendataExplorerRuntimeErrorTestUtil} from '../../../shared/testing/utils/opendata-explorer-runtime-error-test.util';
 import {StationService} from '../../../stac/service/station.service';
@@ -11,6 +12,8 @@ import {stationFeature} from '../reducers/station.reducer';
 import {failLoadingCollectionStations, loadCollectionStations, loadStations} from './station.effects';
 
 describe('StationEffects', () => {
+  const measurementDataType = collectionConfig.defaultMeasurementDataType;
+
   let actions$: Observable<Action>;
   let store: MockStore;
   let stationService: StationService;
@@ -30,7 +33,7 @@ describe('StationEffects', () => {
 
   it('should dispatch loadStations action when loadCollection is dispatched', (done: DoneFn) => {
     const collections = ['collection'];
-    actions$ = of(collectionActions.loadCollections({collections}));
+    actions$ = of(collectionActions.loadCollections({collections, measurementDataType}));
     loadCollectionStations(actions$).subscribe((action) => {
       expect(action).toEqual(stationActions.loadStationsForCollections({collections}));
       done();

--- a/src/app/state/stations/effects/station.effects.ts
+++ b/src/app/state/stations/effects/station.effects.ts
@@ -13,7 +13,7 @@ export const loadCollectionStations = createEffect(
   (actions$ = inject(Actions)) => {
     return actions$.pipe(
       ofType(collectionActions.loadCollections),
-      map(({collections}) => stationActions.loadStationsForCollections({collections})),
+      map(({measurementDataType, collections}) => stationActions.loadStationsForCollections({collections})),
     );
   },
   {functional: true},

--- a/src/app/state/stations/reducers/station.reducer.spec.ts
+++ b/src/app/state/stations/reducers/station.reducer.spec.ts
@@ -1,4 +1,3 @@
-import {produce} from 'immer';
 import {collectionConfig} from '../../../shared/configs/collections.config';
 import {stationActions} from '../actions/station.action';
 import {initialState, stationFeature} from './station.reducer';
@@ -11,14 +10,13 @@ describe('Station Reducer', () => {
   let state: StationState;
 
   beforeEach(() => {
-    state = initialState;
+    state = structuredClone(initialState);
   });
 
   it('should set loadingState to loading when loadStationForCollections is dispatched and loading state is currently not loaded', () => {
-    state = produce(state, (draft) => {
-      draft[measurementDataType].loadingState = 'error';
-    });
+    state[measurementDataType].loadingState = 'error';
     const action = stationActions.loadStationsForCollections({collections: ['test'], measurementDataType});
+
     const result = stationFeature.reducer(state, action);
 
     expect(result[measurementDataType].loadingState).toBe('loading');
@@ -26,10 +24,9 @@ describe('Station Reducer', () => {
   });
 
   it('should not change loadingState if it is already loaded when loadStationForCollections is dispatched', () => {
-    state = produce(state, (draft) => {
-      draft[measurementDataType].loadingState = 'loaded';
-    });
+    state[measurementDataType].loadingState = 'loaded';
     const action = stationActions.loadStationsForCollections({collections: ['test'], measurementDataType});
+
     const result = stationFeature.reducer(state, action);
 
     expect(result[measurementDataType].loadingState).toBe('loaded');
@@ -45,6 +42,7 @@ describe('Station Reducer', () => {
       },
     ];
     const action = stationActions.setLoadedStations({stations, measurementDataType});
+
     const result = stationFeature.reducer(state, action);
 
     expect(result[measurementDataType].loadingState).toBe('loaded');
@@ -53,6 +51,7 @@ describe('Station Reducer', () => {
 
   it('should reset to initialState and set loadingState to error when setStationLoadingError is dispatched', () => {
     const action = stationActions.setStationLoadingError({measurementDataType});
+
     const result = stationFeature.reducer(state, action);
 
     expect(result).toEqual({

--- a/src/app/state/stations/reducers/station.reducer.spec.ts
+++ b/src/app/state/stations/reducers/station.reducer.spec.ts
@@ -1,9 +1,13 @@
+import {produce} from 'immer';
+import {collectionConfig} from '../../../shared/configs/collections.config';
 import {stationActions} from '../actions/station.action';
 import {initialState, stationFeature} from './station.reducer';
 import type {Station} from '../../../shared/models/station';
 import type {StationState} from '../states/station.state';
 
 describe('Station Reducer', () => {
+  const measurementDataType = collectionConfig.defaultMeasurementDataType;
+
   let state: StationState;
 
   beforeEach(() => {
@@ -11,21 +15,25 @@ describe('Station Reducer', () => {
   });
 
   it('should set loadingState to loading when loadStationForCollections is dispatched and loading state is currently not loaded', () => {
-    state = {...state, loadingState: 'error'};
-    const action = stationActions.loadStationsForCollections({collections: ['test']});
+    state = produce(state, (draft) => {
+      draft[measurementDataType].loadingState = 'error';
+    });
+    const action = stationActions.loadStationsForCollections({collections: ['test'], measurementDataType});
     const result = stationFeature.reducer(state, action);
 
-    expect(result.loadingState).toBe('loading');
-    expect(result.stations).toEqual([]);
+    expect(result[measurementDataType].loadingState).toBe('loading');
+    expect(result[measurementDataType].stations).toEqual([]);
   });
 
   it('should not change loadingState if it is already loaded when loadStationForCollections is dispatched', () => {
-    state = {...state, loadingState: 'loaded'};
-    const action = stationActions.loadStationsForCollections({collections: ['test']});
+    state = produce(state, (draft) => {
+      draft[measurementDataType].loadingState = 'loaded';
+    });
+    const action = stationActions.loadStationsForCollections({collections: ['test'], measurementDataType});
     const result = stationFeature.reducer(state, action);
 
-    expect(result.loadingState).toBe('loaded');
-    expect(result.stations).toEqual([]);
+    expect(result[measurementDataType].loadingState).toBe('loaded');
+    expect(result[measurementDataType].stations).toEqual([]);
   });
 
   it('should set stations and loadingState to loaded when setLoadedStations is dispatched', () => {
@@ -36,17 +44,20 @@ describe('Station Reducer', () => {
         coordinates: {longitude: 0, latitude: 0},
       },
     ];
-    const action = stationActions.setLoadedStations({stations});
+    const action = stationActions.setLoadedStations({stations, measurementDataType});
     const result = stationFeature.reducer(state, action);
 
-    expect(result.loadingState).toBe('loaded');
-    expect(result.stations).toEqual(stations);
+    expect(result[measurementDataType].loadingState).toBe('loaded');
+    expect(result[measurementDataType].stations).toEqual(stations);
   });
 
   it('should reset to initialState and set loadingState to error when setStationLoadingError is dispatched', () => {
-    const action = stationActions.setStationLoadingError({});
+    const action = stationActions.setStationLoadingError({measurementDataType});
     const result = stationFeature.reducer(state, action);
 
-    expect(result).toEqual({...initialState, loadingState: 'error'});
+    expect(result).toEqual({
+      ...initialState,
+      [measurementDataType]: {...initialState[measurementDataType], loadingState: 'error'},
+    });
   });
 });

--- a/src/app/state/stations/reducers/station.reducer.ts
+++ b/src/app/state/stations/reducers/station.reducer.ts
@@ -1,13 +1,16 @@
 import {createFeature, createReducer, on} from '@ngrx/store';
+import {produce} from 'immer';
+import {measurementDataTypes} from '../../../shared/models/measurement-data-type';
 import {stationActions} from '../actions/station.action';
-import {StationState} from '../states/station.state';
+import {StationState, StationStateEntry} from '../states/station.state';
 
 export const stationFeatureKey = 'stations';
 
-export const initialState: StationState = {
+export const initialEntryState: StationStateEntry = {
   stations: [],
   loadingState: undefined,
 };
+export const initialState: StationState = Object.fromEntries(measurementDataTypes.map((k) => [k, initialEntryState])) as StationState;
 
 export const stationFeature = createFeature({
   name: stationFeatureKey,
@@ -15,24 +18,23 @@ export const stationFeature = createFeature({
     initialState,
     on(
       stationActions.loadStationsForCollections,
-      (state): StationState => ({
-        ...state,
-        loadingState: state.loadingState !== 'loaded' ? 'loading' : state.loadingState,
+      produce((draft, {measurementDataType}) => {
+        const state = draft[measurementDataType];
+        state.loadingState = state.loadingState !== 'loaded' ? 'loading' : state.loadingState;
       }),
     ),
     on(
       stationActions.setLoadedStations,
-      (state, {stations}): StationState => ({
-        ...state,
-        loadingState: 'loaded',
-        stations: stations,
+      produce((draft, {measurementDataType, stations}) => {
+        const state = draft[measurementDataType];
+        state.stations = stations;
+        state.loadingState = 'loaded';
       }),
     ),
     on(
       stationActions.setStationLoadingError,
-      (): StationState => ({
-        ...initialState,
-        loadingState: 'error',
+      produce((draft, {measurementDataType}) => {
+        draft[measurementDataType] = {...initialEntryState, loadingState: 'error'};
       }),
     ),
   ),

--- a/src/app/state/stations/reducers/station.reducer.ts
+++ b/src/app/state/stations/reducers/station.reducer.ts
@@ -1,6 +1,5 @@
 import {createFeature, createReducer, on} from '@ngrx/store';
 import {produce} from 'immer';
-import {measurementDataTypes} from '../../../shared/models/measurement-data-type';
 import {stationActions} from '../actions/station.action';
 import {StationState, StationStateEntry} from '../states/station.state';
 
@@ -10,7 +9,10 @@ export const initialEntryState: StationStateEntry = {
   stations: [],
   loadingState: undefined,
 };
-export const initialState: StationState = Object.fromEntries(measurementDataTypes.map((k) => [k, initialEntryState])) as StationState;
+export const initialState: StationState = {
+  homogenous: {...initialEntryState},
+  normal: {...initialEntryState},
+};
 
 export const stationFeature = createFeature({
   name: stationFeatureKey,

--- a/src/app/state/stations/selectors/station.selector.spec.ts
+++ b/src/app/state/stations/selectors/station.selector.spec.ts
@@ -21,7 +21,11 @@ describe('Station Selectors', () => {
         {parameterGroupId: 'groupId3', stationId: stationOne.id},
       ];
 
-      const result = selectStationsFilteredByParameterGroups.projector(stations, selectedParameterGroupId, parameterGroupStationMappings);
+      const result = selectStationsFilteredByParameterGroups.projector(
+        {stations, loadingState: 'loaded'},
+        selectedParameterGroupId,
+        parameterGroupStationMappings,
+      );
 
       expect(result).toEqual(jasmine.arrayWithExactContents([stationOne, stationTwo]));
     });
@@ -33,7 +37,11 @@ describe('Station Selectors', () => {
         {parameterGroupId: 'groupId1', stationId: 'nonExistingStationId'},
       ];
 
-      const result = selectStationsFilteredByParameterGroups.projector(stations, selectedParameterGroupId, parameterGroupStationMappings);
+      const result = selectStationsFilteredByParameterGroups.projector(
+        {stations, loadingState: 'loaded'},
+        selectedParameterGroupId,
+        parameterGroupStationMappings,
+      );
 
       expect(result).toEqual([]);
     });
@@ -43,7 +51,11 @@ describe('Station Selectors', () => {
       const selectedParameterGroupId = 'groupId1';
       const parameterGroupStationMappings: ParameterGroupStationMapping[] = [];
 
-      const result = selectStationsFilteredByParameterGroups.projector(stations, selectedParameterGroupId, parameterGroupStationMappings);
+      const result = selectStationsFilteredByParameterGroups.projector(
+        {stations, loadingState: 'loaded'},
+        selectedParameterGroupId,
+        parameterGroupStationMappings,
+      );
 
       expect(result).toEqual([]);
     });
@@ -53,7 +65,11 @@ describe('Station Selectors', () => {
       const selectedParameterGroupId = null;
       const parameterGroupStationMappings: ParameterGroupStationMapping[] = [{parameterGroupId: 'groupId1', stationId: stationOne.id}];
 
-      const result = selectStationsFilteredByParameterGroups.projector(stations, selectedParameterGroupId, parameterGroupStationMappings);
+      const result = selectStationsFilteredByParameterGroups.projector(
+        {stations, loadingState: 'loaded'},
+        selectedParameterGroupId,
+        parameterGroupStationMappings,
+      );
 
       expect(result).toEqual(jasmine.arrayWithExactContents([stationOne, stationTwo, stationThree]));
     });

--- a/src/app/state/stations/selectors/station.selector.ts
+++ b/src/app/state/stations/selectors/station.selector.ts
@@ -3,19 +3,26 @@ import {Station} from '../../../shared/models/station';
 import {formFeature} from '../../form/reducers/form.reducer';
 import {selectParameterGroupStationMappings} from '../../parameter-station-mapping/selectors/parameter-group-station-mapping.selector';
 import {stationFeature} from '../reducers/station.reducer';
+import {StationStateEntry} from '../states/station.state';
+
+export const selectCurrentStationState = createSelector(
+  stationFeature.selectStationsState,
+  formFeature.selectSelectedMeasurementDataType,
+  (stationState, measurementDataType): StationStateEntry => stationState[measurementDataType],
+);
 
 export const selectStationsFilteredByParameterGroups = createSelector(
-  stationFeature.selectStations,
+  selectCurrentStationState,
   formFeature.selectSelectedParameterGroupId,
   selectParameterGroupStationMappings,
-  (stations, parameterGroupId, parameterGroupStationMappings): Station[] => {
+  (stationState, parameterGroupId, parameterGroupStationMappings): Station[] => {
     if (!parameterGroupId) {
-      return stations;
+      return stationState.stations;
     }
 
     const matchingStationIds = parameterGroupStationMappings
       .filter((mapping) => mapping.parameterGroupId === parameterGroupId)
       .map((mapping) => mapping.stationId);
-    return stations.filter((station) => matchingStationIds.includes(station.id));
+    return stationState.stations.filter((station) => matchingStationIds.includes(station.id));
   },
 );

--- a/src/app/state/stations/states/station.state.ts
+++ b/src/app/state/stations/states/station.state.ts
@@ -1,6 +1,9 @@
 import {LoadableState} from '../../../shared/models/loadable-state';
+import {MeasurementDataType} from '../../../shared/models/measurement-data-type';
 import {Station} from '../../../shared/models/station';
 
-export interface StationState extends LoadableState {
+export interface StationStateEntry extends LoadableState {
   stations: Station[];
 }
+
+export type StationState = Record<MeasurementDataType, StationStateEntry>;


### PR DESCRIPTION
The parameters and stations should be selected based on a selected
measurement data type. Each measurement data type defines a set of
collections that are loaded with their own stations and parameters. The
form behaves the same for each measurement type, except that the data of
each measurement type is not mixed with the others.

Changing the measurement data type selection loads the corresponding
collections, if they are not loaded yet.