### PR TITLE
Refactor effects registration #32

### DIFF
--- a/src/app/state/index.ts
+++ b/src/app/state/index.ts
@@ -1,17 +1,14 @@
 import {formFeature, formFeatureKey} from './form/reducers/form.reducer';
-import {addStationsToMap, filterStationsOnMap} from './map/effects/map.effects';
-import {
-  loadCollectionParameterStationMappings,
-  loadParameterStationMappings,
-} from './parameter-station-mapping/effects/parameter-station-mapping.effects';
+import * as mapEffects from './map/effects/map.effects';
+import * as parameterStationMappingEffects from './parameter-station-mapping/effects/parameter-station-mapping.effects';
 import {
   parameterStationMappingFeature,
   parameterStationMappingFeatureKey,
 } from './parameter-station-mapping/reducers/parameter-station-mapping.reducer';
 import {ParameterStationMappingState} from './parameter-station-mapping/states/parameter-station-mapping.state';
-import {failLoadingCollectionParameters, loadCollectionParameters, loadParameters} from './parameters/effects/parameter.effects';
+import * as parameterEffects from './parameters/effects/parameter.effects';
 import {parameterFeature, parameterFeatureKey} from './parameters/reducers/parameter.reducer';
-import {failLoadingCollectionStations, loadCollectionStations, loadStations} from './stations/effects/station.effects';
+import * as stationEffects from './stations/effects/station.effects';
 import {stationFeature, stationFeatureKey} from './stations/reducers/station.reducer';
 import type {Type} from '@angular/core';
 import type {FunctionalEffect} from '@ngrx/effects';
@@ -33,9 +30,9 @@ export const reducers: ActionReducerMap<State> = {
   [parameterStationMappingFeatureKey]: parameterStationMappingFeature.reducer,
 };
 export const effects: (Type<unknown> | Record<string, FunctionalEffect>)[] = [
-  {loadCollectionParameters, loadParameters, failLoadingCollectionParameters},
-  {loadStations, loadCollectionStations, failLoadingCollectionStations},
-  {addStationsToMap, filterStationsOnMap},
-  {loadParameterStationMappings, loadCollectionParameterStationMappings},
+  parameterEffects,
+  stationEffects,
+  mapEffects,
+  parameterStationMappingEffects,
 ];
 export const metaReducers: MetaReducer<State>[] = [];


### PR DESCRIPTION
Effects need to be registered in ngrx for them to take effect. We did this by defining an array where all effects are put in and this array is given to ngrx. ngrx expects the contents of the array to be objects containing effect functions not the functions themselves, which is why we had objects wrapping the different effects in the array.

However, we tend to forget to register the effects. This can lead to unintended effects, like an error handler not triggering. When using Effects classes this problem is solved by providing the class to ngrx which contains all effects. However, we are using functional effects so we have to do that a bit differently.

To make effects automatically registered, we import all exported members of the effects file using a * import and alias it to a meaningful name. This allows us to have an object containing all effects, as the imported module acts like an object in JavaScript terms. This way we can just add the aliased imports to the array and don't need to worry about forgetting an import.

However, this means that effects files cannot export anything else but effects. But they should not need to do that anyway. In the worst case we have to either filter the members of the import for effects or specify the imports manually and alias them.