### PR TITLE
Integrate map into state #34

### DIFF
--- a/public/i18n/de.json
+++ b/public/i18n/de.json
@@ -10,6 +10,8 @@
   "form.stepper.time-range.label": "Missing value for 'form.stepper.time-range.label'",
   "form.stepper.overview.label": "Missing value for 'form.stepper.overview.label'",
   "form.stepper.download.label": "Missing value for 'form.stepper.download.label'",
+  "map.load.error": "Missing value for 'map.load.error'",
+  "map.not.initialized.error": "Missing value for 'map.not.initialized.error'",
   "now-time-interval": "Missing value for 'now-time-interval'",
   "recent-time-interval": "Missing value for 'recent-time-interval'",
   "historical-time-range-explanation": "Missing value for 'historical-time-range-explanation'",

--- a/public/i18n/de.json
+++ b/public/i18n/de.json
@@ -11,7 +11,7 @@
   "form.stepper.overview.label": "Missing value for 'form.stepper.overview.label'",
   "form.stepper.download.label": "Missing value for 'form.stepper.download.label'",
   "map.load.error": "Missing value for 'map.load.error'",
-  "map.not.initialized.error": "Missing value for 'map.not.initialized.error'",
+  "map.not-initialized.error": "Missing value for 'map.not-initialized.error'",
   "now-time-interval": "Missing value for 'now-time-interval'",
   "recent-time-interval": "Missing value for 'recent-time-interval'",
   "historical-time-range-explanation": "Missing value for 'historical-time-range-explanation'",

--- a/public/i18n/en.json
+++ b/public/i18n/en.json
@@ -10,6 +10,8 @@
   "form.stepper.time-range.label": "Missing value for 'form.stepper.time-range.label'",
   "form.stepper.overview.label": "Missing value for 'form.stepper.overview.label'",
   "form.stepper.download.label": "Missing value for 'form.stepper.download.label'",
+  "map.load.error": "Missing value for 'map.load.error'",
+  "map.not.initialized.error": "Missing value for 'map.not.initialized.error'",
   "now-time-interval": "Missing value for 'now-time-interval'",
   "recent-time-interval": "Missing value for 'recent-time-interval'",
   "historical-time-range-explanation": "Missing value for 'historical-time-range-explanation'",

--- a/public/i18n/en.json
+++ b/public/i18n/en.json
@@ -11,7 +11,7 @@
   "form.stepper.overview.label": "Missing value for 'form.stepper.overview.label'",
   "form.stepper.download.label": "Missing value for 'form.stepper.download.label'",
   "map.load.error": "Missing value for 'map.load.error'",
-  "map.not.initialized.error": "Missing value for 'map.not.initialized.error'",
+  "map.not-initialized.error": "Missing value for 'map.not-initialized.error'",
   "now-time-interval": "Missing value for 'now-time-interval'",
   "recent-time-interval": "Missing value for 'recent-time-interval'",
   "historical-time-range-explanation": "Missing value for 'historical-time-range-explanation'",

--- a/public/i18n/fr.json
+++ b/public/i18n/fr.json
@@ -10,6 +10,8 @@
   "form.stepper.time-range.label": "Missing value for 'form.stepper.time-range.label'",
   "form.stepper.overview.label": "Missing value for 'form.stepper.overview.label'",
   "form.stepper.download.label": "Missing value for 'form.stepper.download.label'",
+  "map.load.error": "Missing value for 'map.load.error'",
+  "map.not.initialized.error": "Missing value for 'map.not.initialized.error'",
   "now-time-interval": "Missing value for 'now-time-interval'",
   "recent-time-interval": "Missing value for 'recent-time-interval'",
   "historical-time-range-explanation": "Missing value for 'historical-time-range-explanation'",

--- a/public/i18n/fr.json
+++ b/public/i18n/fr.json
@@ -11,7 +11,7 @@
   "form.stepper.overview.label": "Missing value for 'form.stepper.overview.label'",
   "form.stepper.download.label": "Missing value for 'form.stepper.download.label'",
   "map.load.error": "Missing value for 'map.load.error'",
-  "map.not.initialized.error": "Missing value for 'map.not.initialized.error'",
+  "map.not-initialized.error": "Missing value for 'map.not-initialized.error'",
   "now-time-interval": "Missing value for 'now-time-interval'",
   "recent-time-interval": "Missing value for 'recent-time-interval'",
   "historical-time-range-explanation": "Missing value for 'historical-time-range-explanation'",

--- a/public/i18n/it.json
+++ b/public/i18n/it.json
@@ -10,6 +10,8 @@
   "form.stepper.time-range.label": "Missing value for 'form.stepper.time-range.label'",
   "form.stepper.overview.label": "Missing value for 'form.stepper.overview.label'",
   "form.stepper.download.label": "Missing value for 'form.stepper.download.label'",
+  "map.load.error": "Missing value for 'map.load.error'",
+  "map.not.initialized.error": "Missing value for 'map.not.initialized.error'",
   "now-time-interval": "Missing value for 'now-time-interval'",
   "recent-time-interval": "Missing value for 'recent-time-interval'",
   "historical-time-range-explanation": "Missing value for 'historical-time-range-explanation'",

--- a/public/i18n/it.json
+++ b/public/i18n/it.json
@@ -11,7 +11,7 @@
   "form.stepper.overview.label": "Missing value for 'form.stepper.overview.label'",
   "form.stepper.download.label": "Missing value for 'form.stepper.download.label'",
   "map.load.error": "Missing value for 'map.load.error'",
-  "map.not.initialized.error": "Missing value for 'map.not.initialized.error'",
+  "map.not-initialized.error": "Missing value for 'map.not-initialized.error'",
   "now-time-interval": "Missing value for 'now-time-interval'",
   "recent-time-interval": "Missing value for 'recent-time-interval'",
   "historical-time-range-explanation": "Missing value for 'historical-time-range-explanation'",

--- a/src/app/map/components/map-container/map-container.component.ts
+++ b/src/app/map/components/map-container/map-container.component.ts
@@ -1,5 +1,7 @@
 import {AfterViewInit, Component, ElementRef, inject, OnDestroy, ViewChild} from '@angular/core';
+import {Store} from '@ngrx/store';
 import {mapConfig} from '../../../shared/configs/map.config';
+import {mapActions} from '../../../state/map/actions/map.action';
 import {MapService} from '../../services/map.service';
 
 @Component({
@@ -10,14 +12,16 @@ import {MapService} from '../../services/map.service';
   styleUrl: './map-container.component.scss',
 })
 export class MapContainerComponent implements AfterViewInit, OnDestroy {
+  private readonly store = inject(Store);
   private readonly mapService = inject(MapService);
   @ViewChild('map', {static: true}) private readonly openLayerMapElementRef!: ElementRef<HTMLDivElement>;
 
-  public async ngAfterViewInit(): Promise<void> {
-    await this.mapService.createMap(this.openLayerMapElementRef.nativeElement, mapConfig);
+  public ngAfterViewInit(): void {
+    this.mapService.createMap(this.openLayerMapElementRef.nativeElement, mapConfig);
+    this.store.dispatch(mapActions.loadMap());
   }
 
   public ngOnDestroy(): void {
-    this.mapService.removeMap();
+    this.store.dispatch(mapActions.resetState());
   }
 }

--- a/src/app/map/models/map-viewport.ts
+++ b/src/app/map/models/map-viewport.ts
@@ -1,0 +1,19 @@
+import {Coordinates} from '../../shared/models/coordinates';
+
+interface MapViewportBase {
+  type: 'boundingBox' | 'centerAndZoom';
+}
+
+export interface BoundingBox extends MapViewportBase {
+  type: 'boundingBox';
+  northEast: Coordinates;
+  southWest: Coordinates;
+}
+
+export interface CenterAndZoom extends MapViewportBase {
+  type: 'centerAndZoom';
+  center: Coordinates;
+  zoom: number;
+}
+
+export type MapViewport = BoundingBox | CenterAndZoom;

--- a/src/app/map/services/map.service.spec.ts
+++ b/src/app/map/services/map.service.spec.ts
@@ -1,9 +1,11 @@
 import {HttpClient, provideHttpClient} from '@angular/common/http';
 import {TestBed} from '@angular/core/testing';
-import {Map} from 'maplibre-gl';
+import {StyleSpecification} from '@maplibre/maplibre-gl-style-spec';
+import {LngLat, Map} from 'maplibre-gl';
 import {of} from 'rxjs';
 import {MapConfig} from '../../shared/models/configs/map-config';
 import {Station} from '../../shared/models/station';
+import {MapViewport} from '../models/map-viewport';
 import {styleSpecificationMock} from '../testing/data/style-specification.mock';
 import {MapService} from './map.service';
 
@@ -24,68 +26,82 @@ describe('MapService', () => {
     expect(service).toBeTruthy();
   });
 
-  it('should create a map with the given configuration', async () => {
+  it('should create a map with the given configuration', () => {
+    spyOn(service, 'removeMap');
     const target = document.createElement('div');
-    const httpGetSpy = spyOn(httpClient, 'get').and.returnValue(of(styleSpecificationMock));
-    const mapConfig: MapConfig = {
-      styleUrl: 'map-style-url',
-      boundingBox: [
-        {longitude: 0, latitude: 0},
-        {longitude: 1, latitude: 1},
-      ],
-      enableRotation: true,
-    };
+    const mapConfig = {
+      defaultBoundingBox: {
+        type: 'boundingBox',
+        southWest: {longitude: 0, latitude: 0},
+        northEast: {longitude: 1, latitude: 1},
+      },
+      enableRotation: false,
+    } as Partial<MapConfig> as MapConfig;
 
-    const map = await service.createMap(target, mapConfig);
+    service.createMap(target, mapConfig);
 
+    // eslint-disable-next-line @typescript-eslint/dot-notation -- necessary for this one test
+    const map = service['map'];
     expect(map).toBeDefined();
-    expect(map.getContainer()).toBe(target);
-    expect(httpGetSpy).toHaveBeenCalledOnceWith('map-style-url');
-  });
-
-  // TODO: this is disabled until we finalize the implementation of the custom styling.
-  xit('should create a map where layers have been filtered', async () => {
-    const target = document.createElement('div');
-    spyOn(httpClient, 'get').and.returnValue(of(styleSpecificationMock));
-    const mapConfig: MapConfig = {
-      styleUrl: 'map-style-url',
-      boundingBox: [
-        {longitude: 0, latitude: 0},
-        {longitude: 1, latitude: 1},
-      ],
-      enableRotation: true,
-    };
-
-    const map = await service.createMap(target, mapConfig);
-
-    expect(map.getStyle()).toBeDefined();
-    expect(map.getStyle().layers.length).toEqual(1);
-    expect(map.getStyle().layers[0].id).toEqual('background');
+    expect(map!.getContainer()).toBe(target);
+    expect(map!.getBounds().getEast()).toBeCloseTo(1, 0.5);
+    expect(map!.getBounds().getNorth()).toBeCloseTo(1, 0.5);
+    expect(map!.getBounds().getSouth()).toBeCloseTo(0, 0.5);
+    expect(map!.getBounds().getWest()).toBeCloseTo(0, 0.5);
+    expect(service.removeMap).toHaveBeenCalledOnceWith();
   });
 
   describe('when the map is created', () => {
     let map: Map;
 
-    beforeEach(async () => {
+    beforeEach(() => {
       const target = document.createElement('div');
-      spyOn(httpClient, 'get').and.returnValue(of(styleSpecificationMock));
-      const mapConfig: MapConfig = {
-        styleUrl: 'map-style-url',
-        boundingBox: [
-          {longitude: 0, latitude: 0},
-          {longitude: 1, latitude: 1},
-        ],
-        enableRotation: true,
+      const mapConfig = {
+        defaultBoundingBox: {
+          type: 'boundingBox',
+          southWest: {longitude: 0, latitude: 0},
+          northEast: {longitude: 1, latitude: 1},
+        },
+        enableRotation: false,
+      } as Partial<MapConfig> as MapConfig;
+      service.createMap(target, mapConfig);
+
+      // eslint-disable-next-line @typescript-eslint/dot-notation -- necessary for this one test
+      map = service['map']!;
+    });
+
+    it('should initialize the map with the given viewport', async () => {
+      const mapConfig = {
+        styleUrl: 'style-url',
+      } as Partial<MapConfig> as MapConfig;
+      const initialMapViewport: MapViewport = {
+        type: 'centerAndZoom',
+        center: {longitude: 0, latitude: 1},
+        zoom: 2,
       };
-      map = await service.createMap(target, mapConfig);
+      const httpGetSpy = spyOn(httpClient, 'get').and.returnValue(of(styleSpecificationMock));
+      spyOn(map, 'setCenter');
+      spyOn(map, 'setZoom');
+      spyOn(map, 'once').and.returnValue(Promise.resolve());
+      const setStyleSpy = spyOn(map, 'setStyle');
+
+      await service.initializeMap(mapConfig, initialMapViewport);
+
+      expect(httpGetSpy).toHaveBeenCalledOnceWith('style-url');
+      expect(map.setCenter).toHaveBeenCalledOnceWith(new LngLat(0, 1), {animate: false});
+      expect(map.setZoom).toHaveBeenCalledOnceWith(2, {animate: false});
+      expect(setStyleSpy).toHaveBeenCalledTimes(1);
+      const styleSpecification = setStyleSpy.calls.first().args[0] as StyleSpecification;
+      expect(styleSpecification.layers.length).toEqual(1);
+      expect(styleSpecification.layers[0].id).toEqual('background');
     });
 
     it('should remove the map', () => {
-      const mapRemoveSpy = spyOn(map, 'remove');
+      spyOn(map, 'remove');
 
       service.removeMap();
 
-      expect(mapRemoveSpy).toHaveBeenCalled();
+      expect(map.remove).toHaveBeenCalledOnceWith();
     });
 
     it('should add stations to the map', () => {
@@ -96,28 +112,24 @@ describe('MapService', () => {
           coordinates: {longitude: 0, latitude: 0},
         },
       ];
-      const mapAddSourceSpy = spyOn(map, 'addSource');
-      const mapAddLayerSpy = spyOn(map, 'addLayer');
+      spyOn(map, 'addSource');
+      spyOn(map, 'addLayer');
+      spyOn(map, 'getLayer').and.returnValue(undefined);
+      spyOn(map, 'getSource').and.returnValue(undefined);
 
       service.addStationsToMap(stations);
 
-      expect(mapAddSourceSpy).toHaveBeenCalled();
-      expect(mapAddLayerSpy).toHaveBeenCalledTimes(2); // circle and label layer
+      expect(map.addSource).toHaveBeenCalled();
+      expect(map.addLayer).toHaveBeenCalledTimes(2); // circle and label layer
     });
 
     it('should filter stations from the map', () => {
-      const stations: Station[] = [
-        {
-          id: 'station-id',
-          name: 'station-name',
-          coordinates: {longitude: 0, latitude: 0},
-        },
-      ];
-      const mapFilterSpy = spyOn(map, 'setFilter');
+      const stationIds: string[] = ['station-id'];
+      spyOn(map, 'setFilter');
 
-      service.filterStationsOnMap(stations);
+      service.filterStationsOnMap(stationIds);
 
-      expect(mapFilterSpy).toHaveBeenCalled();
+      expect(map.setFilter).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/src/app/map/services/map.service.spec.ts
+++ b/src/app/map/services/map.service.spec.ts
@@ -37,7 +37,7 @@ describe('MapService', () => {
         northEast: {longitude: 1, latitude: 1},
       },
       enableRotation: false,
-    } as Partial<MapConfig> as MapConfig;
+    } as MapConfig;
 
     service.createMap(target, mapConfig);
 
@@ -66,7 +66,7 @@ describe('MapService', () => {
           northEast: {longitude: 1, latitude: 1},
         },
         enableRotation: false,
-      } as Partial<MapConfig> as MapConfig;
+      } as MapConfig;
       service.createMap(target, mapConfig);
 
       // eslint-disable-next-line @typescript-eslint/dot-notation -- necessary because the map should be only available within the service
@@ -76,7 +76,7 @@ describe('MapService', () => {
     it('should initialize the map with the given viewport', async () => {
       const mapConfig = {
         styleUrl: 'style-url',
-      } as Partial<MapConfig> as MapConfig;
+      } as MapConfig;
       const initialMapViewport: MapViewport = {
         type: 'centerAndZoom',
         center: {longitude: 0, latitude: 1},

--- a/src/app/map/services/map.service.ts
+++ b/src/app/map/services/map.service.ts
@@ -75,7 +75,7 @@ export class MapService {
   }
 
   public createInitialMapViewport(zoom: number | undefined, center: Coordinates | undefined, mapConfig: MapConfig): MapViewport {
-    return center || zoom
+    return center !== undefined || zoom !== undefined
       ? {
           type: 'centerAndZoom',
           center: center ?? mapConfig.defaultZoomAndCenter.center,

--- a/src/app/map/services/map.service.ts
+++ b/src/app/map/services/map.service.ts
@@ -1,12 +1,14 @@
 import {HttpClient} from '@angular/common/http';
 import {inject, Injectable} from '@angular/core';
 import {StyleSpecification} from '@maplibre/maplibre-gl-style-spec';
+import {Store} from '@ngrx/store';
 import {CircleLayerSpecification, LayerSpecification, LngLat, LngLatBounds, Map, MapOptions, SymbolLayerSpecification} from 'maplibre-gl';
-import {firstValueFrom} from 'rxjs';
+import {firstValueFrom, Subscription} from 'rxjs';
 import {MapNotInitializedError} from '../../shared/errors/map.error';
 import {MapConfig} from '../../shared/models/configs/map-config';
 import {Coordinates} from '../../shared/models/coordinates';
 import {Station} from '../../shared/models/station';
+import {mapActions} from '../../state/map/actions/map.action';
 import {MapViewport} from '../models/map-viewport';
 
 @Injectable({
@@ -14,8 +16,10 @@ import {MapViewport} from '../models/map-viewport';
 })
 export class MapService {
   private readonly http = inject(HttpClient);
+  private readonly store = inject(Store);
 
   private map?: Map;
+  private mapSubscriptions?: Subscription;
   private readonly stationSourceId = 'stations' as const;
   private readonly stationLayerId = 'stations' as const;
   private readonly stationLabelLayerId = 'stations-label' as const;
@@ -60,9 +64,12 @@ export class MapService {
     style.layers = this.filterUnnecessaryLayers(style.layers);
     map.setStyle(style);
     await map.once('load');
+    this.subscribeToMapEvents();
   }
 
   public removeMap(): void {
+    this.mapSubscriptions?.unsubscribe();
+    this.mapSubscriptions = undefined;
     this.map?.remove();
     this.map = undefined;
   }
@@ -131,6 +138,27 @@ export class MapService {
       throw new MapNotInitializedError();
     }
     map.setFilter(this.stationSourceId, ['in', 'id', ...stationIds]);
+  }
+
+  private subscribeToMapEvents(): void {
+    const map = this.map;
+    if (!map) {
+      throw new MapNotInitializedError();
+    }
+    if (this.mapSubscriptions) {
+      this.mapSubscriptions.unsubscribe();
+    }
+    this.mapSubscriptions = new Subscription();
+    this.mapSubscriptions.add(map.on('zoom', () => this.dispatchZoomChanges(map.getZoom())));
+    this.mapSubscriptions.add(map.on('move', () => this.dispatchCenterChanges(map.getCenter())));
+  }
+
+  private dispatchZoomChanges(zoom: number): void {
+    this.store.dispatch(mapActions.setZoom({zoom}));
+  }
+
+  private dispatchCenterChanges(center: LngLat): void {
+    this.store.dispatch(mapActions.setCenter({center: {latitude: center.lat, longitude: center.lng}}));
   }
 
   private async fetchStyle(styleUrl: string): Promise<StyleSpecification> {

--- a/src/app/map/services/map.service.ts
+++ b/src/app/map/services/map.service.ts
@@ -1,10 +1,13 @@
 import {HttpClient} from '@angular/common/http';
 import {inject, Injectable} from '@angular/core';
 import {StyleSpecification} from '@maplibre/maplibre-gl-style-spec';
-import {CircleLayerSpecification, LayerSpecification, LngLat, LngLatBounds, Map, SymbolLayerSpecification} from 'maplibre-gl';
+import {CircleLayerSpecification, LayerSpecification, LngLat, LngLatBounds, Map, MapOptions, SymbolLayerSpecification} from 'maplibre-gl';
 import {firstValueFrom} from 'rxjs';
+import {MapNotInitializedError} from '../../shared/errors/map.error';
 import {MapConfig} from '../../shared/models/configs/map-config';
+import {Coordinates} from '../../shared/models/coordinates';
 import {Station} from '../../shared/models/station';
+import {MapViewport} from '../models/map-viewport';
 
 @Injectable({
   providedIn: 'root',
@@ -17,23 +20,46 @@ export class MapService {
   private readonly stationLayerId = 'stations' as const;
   private readonly stationLabelLayerId = 'stations-label' as const;
 
-  public async createMap(target: HTMLElement, mapConfig: MapConfig): Promise<Map> {
+  public createMap(target: HTMLElement, mapConfig: MapConfig): void {
     this.removeMap();
+    const mapOptions: MapOptions = {
+      container: target,
+      dragRotate: mapConfig.enableRotation,
+      bounds: new LngLatBounds(
+        new LngLat(mapConfig.defaultBoundingBox.southWest.longitude, mapConfig.defaultBoundingBox.southWest.latitude),
+        new LngLat(mapConfig.defaultBoundingBox.northEast.longitude, mapConfig.defaultBoundingBox.northEast.latitude),
+      ),
+    };
+    this.map = new Map(mapOptions);
+  }
+
+  public async initializeMap(mapConfig: MapConfig, initialMapViewport: MapViewport): Promise<void> {
+    const map = this.map;
+    if (!map) {
+      throw new MapNotInitializedError();
+    }
+
+    switch (initialMapViewport.type) {
+      case 'boundingBox': {
+        map.fitBounds(
+          new LngLatBounds(
+            new LngLat(initialMapViewport.southWest.longitude, initialMapViewport.southWest.latitude),
+            new LngLat(initialMapViewport.northEast.longitude, initialMapViewport.northEast.latitude),
+          ),
+          {animate: false},
+        );
+        break;
+      }
+      case 'centerAndZoom': {
+        map.setCenter(new LngLat(initialMapViewport.center.longitude, initialMapViewport.center.latitude), {animate: false});
+        map.setZoom(initialMapViewport.zoom, {animate: false});
+        break;
+      }
+    }
     const style = await this.fetchStyle(mapConfig.styleUrl);
     style.layers = this.filterUnnecessaryLayers(style.layers);
-    this.map = new Map({
-      container: target,
-      style,
-      bounds: new LngLatBounds(
-        new LngLat(mapConfig.boundingBox[0].longitude, mapConfig.boundingBox[0].latitude),
-        new LngLat(mapConfig.boundingBox[1].longitude, mapConfig.boundingBox[1].latitude),
-      ),
-      dragRotate: mapConfig.enableRotation,
-    });
-    // TODO: Either make sure sure that the filters are applied to the map
-    //       or to change the `map` member into a BehaviorSubject and apply the filter
-    //       as soon as it is not `undefined` anymore.
-    return this.map;
+    map.setStyle(style);
+    await map.once('load');
   }
 
   public removeMap(): void {
@@ -41,10 +67,20 @@ export class MapService {
     this.map = undefined;
   }
 
+  public createInitialMapViewport(zoom: number | undefined, center: Coordinates | undefined, mapConfig: MapConfig): MapViewport {
+    return center || zoom
+      ? {
+          type: 'centerAndZoom',
+          center: center ?? mapConfig.defaultZoomAndCenter.center,
+          zoom: zoom ?? mapConfig.defaultZoomAndCenter.zoom,
+        }
+      : mapConfig.defaultBoundingBox;
+  }
+
   public addStationsToMap(stations: Station[]): void {
     const map = this.map;
     if (!map) {
-      return;
+      throw new MapNotInitializedError();
     }
     this.removeStationsFromMap();
     map.addSource(this.stationSourceId, {
@@ -89,12 +125,12 @@ export class MapService {
     } satisfies SymbolLayerSpecification);
   }
 
-  public filterStationsOnMap(stations: Station[]): void {
+  public filterStationsOnMap(stationIds: string[]): void {
     const map = this.map;
     if (!map) {
-      return;
+      throw new MapNotInitializedError();
     }
-    map.setFilter(this.stationSourceId, ['in', 'id', ...stations.map((station) => station.id)]);
+    map.setFilter(this.stationSourceId, ['in', 'id', ...stationIds]);
   }
 
   private async fetchStyle(styleUrl: string): Promise<StyleSpecification> {
@@ -104,7 +140,7 @@ export class MapService {
   private removeStationsFromMap(): void {
     const map = this.map;
     if (!map) {
-      return;
+      throw new MapNotInitializedError();
     }
     if (map.getLayer(this.stationLayerId)) {
       map.removeLayer(this.stationLayerId);

--- a/src/app/shared/configs/map.config.ts
+++ b/src/app/shared/configs/map.config.ts
@@ -2,9 +2,15 @@ import {type MapConfig} from '../models/configs/map-config';
 
 export const mapConfig = {
   styleUrl: 'https://vectortiles.geo.admin.ch/styles/ch.swisstopo.basemap.vt/style.json',
-  boundingBox: [
-    {longitude: 6.02260949059, latitude: 45.7769477403},
-    {longitude: 10.4427014502, latitude: 47.8308275417},
-  ],
   enableRotation: false,
+  defaultBoundingBox: {
+    type: 'boundingBox',
+    southWest: {longitude: 6.02260949059, latitude: 45.7769477403},
+    northEast: {longitude: 10.4427014502, latitude: 47.8308275417},
+  },
+  defaultZoomAndCenter: {
+    type: 'centerAndZoom',
+    center: {longitude: 8.231974, latitude: 46.818187},
+    zoom: 6,
+  },
 } as const satisfies MapConfig;

--- a/src/app/shared/errors/map.error.ts
+++ b/src/app/shared/errors/map.error.ts
@@ -1,0 +1,10 @@
+import {marker} from '@jsverse/transloco-keys-manager/marker';
+import {FatalError, SilentError} from './base.error';
+
+export class MapError extends FatalError {
+  public override message = marker('map.load.error');
+}
+
+export class MapNotInitializedError extends SilentError {
+  public override message = marker('map.not.initialized.error');
+}

--- a/src/app/shared/errors/map.error.ts
+++ b/src/app/shared/errors/map.error.ts
@@ -1,10 +1,10 @@
 import {marker} from '@jsverse/transloco-keys-manager/marker';
 import {FatalError, SilentError} from './base.error';
 
-export class MapError extends FatalError {
+export class MapLoadError extends FatalError {
   public override message = marker('map.load.error');
 }
 
 export class MapNotInitializedError extends SilentError {
-  public override message = marker('map.not.initialized.error');
+  public override message = marker('map.not-initialized.error');
 }

--- a/src/app/shared/models/configs/map-config.ts
+++ b/src/app/shared/models/configs/map-config.ts
@@ -1,7 +1,8 @@
-import {Coordinates} from '../coordinates';
+import {BoundingBox, CenterAndZoom} from '../../../map/models/map-viewport';
 
 export interface MapConfig {
   styleUrl: string;
-  boundingBox: [Coordinates, Coordinates];
   enableRotation: boolean;
+  defaultBoundingBox: BoundingBox;
+  defaultZoomAndCenter: CenterAndZoom;
 }

--- a/src/app/state/index.ts
+++ b/src/app/state/index.ts
@@ -1,6 +1,8 @@
 import * as formEffects from './form/effects/form.effects';
 import {formFeature, formFeatureKey} from './form/reducers/form.reducer';
 import * as mapEffects from './map/effects/map.effects';
+import {mapFeature, mapFeatureKey} from './map/reducers/map.reducer';
+import {MapState} from './map/states/map.state';
 import * as parameterStationMappingEffects from './parameter-station-mapping/effects/parameter-station-mapping.effects';
 import {
   parameterStationMappingFeature,
@@ -23,12 +25,14 @@ export interface State {
   [stationFeatureKey]: StationState;
   [formFeatureKey]: FormState;
   [parameterStationMappingFeatureKey]: ParameterStationMappingState;
+  [mapFeatureKey]: MapState;
 }
 export const reducers: ActionReducerMap<State> = {
   [parameterFeatureKey]: parameterFeature.reducer,
   [stationFeatureKey]: stationFeature.reducer,
   [formFeatureKey]: formFeature.reducer,
   [parameterStationMappingFeatureKey]: parameterStationMappingFeature.reducer,
+  [mapFeatureKey]: mapFeature.reducer,
 };
 export const effects: (Type<unknown> | Record<string, FunctionalEffect>)[] = [
   parameterEffects,

--- a/src/app/state/map/actions/map.action.ts
+++ b/src/app/state/map/actions/map.action.ts
@@ -1,0 +1,15 @@
+import {createActionGroup, emptyProps, props} from '@ngrx/store';
+import {Coordinates} from '../../../shared/models/coordinates';
+import {errorProps} from '../../utils/error-props.util';
+
+export const mapActions = createActionGroup({
+  source: 'Maps',
+  events: {
+    'Load map': emptyProps(),
+    'Set map as loaded': emptyProps(),
+    'Set map loading error': errorProps(),
+    'Reset state': emptyProps(),
+    'Set zoom': props<{zoom: number}>(),
+    'Set center': props<{center: Coordinates}>(),
+  },
+});

--- a/src/app/state/map/effects/map.effects.spec.ts
+++ b/src/app/state/map/effects/map.effects.spec.ts
@@ -1,47 +1,135 @@
+import {provideHttpClient} from '@angular/common/http';
 import {TestBed} from '@angular/core/testing';
 import {Action} from '@ngrx/store';
 import {MockStore, provideMockStore} from '@ngrx/store/testing';
-import {Observable, of} from 'rxjs';
+import {catchError, EMPTY, Observable, of} from 'rxjs';
 import {MapService} from '../../../map/services/map.service';
-import {collectionConfig} from '../../../shared/configs/collections.config';
+import {MapError} from '../../../shared/errors/map.error';
 import {Station} from '../../../shared/models/station';
-import {formActions} from '../../form/actions/form.actions';
-import {stationActions} from '../../stations/actions/station.action';
-import {selectCurrentStationState} from '../../stations/selectors/station.selector';
-import {addStationsToMap, filterStationsOnMap} from './map.effects';
+import {OpendataExplorerRuntimeErrorTestUtil} from '../../../shared/testing/utils/opendata-explorer-runtime-error-test.util';
+import {selectCurrentStationState, selectStationIdsFilteredBySelectedParameterGroups} from '../../stations/selectors/station.selector';
+import {mapActions} from '../actions/map.action';
+import {mapFeature} from '../reducers/map.reducer';
+import {addStationsToMap, failLoadingMap, filterStationsOnMap, initializeMap, removeMap} from './map.effects';
 
 describe('MapEffects', () => {
   let actions$: Observable<Action>;
   let store: MockStore;
-  let mapService: jasmine.SpyObj<MapService>;
+  let mapService: MapService;
 
   beforeEach(() => {
-    mapService = jasmine.createSpyObj('MapService', ['addStationsToMap', 'filterStationsOnMap']);
     TestBed.configureTestingModule({
-      providers: [provideMockStore()],
+      providers: [provideMockStore(), provideHttpClient()],
     });
     store = TestBed.inject(MockStore);
+    mapService = TestBed.inject(MapService);
   });
 
   afterEach(() => {
     store.resetSelectors();
   });
 
-  it('should add stations to the map when stationActions.setLoadedStations is dispatched', (done) => {
+  it('should dispatch the setMapAsLoaded action after successfully loading map using the action loadMap', (done: DoneFn) => {
+    spyOn(mapService, 'createInitialMapViewport').and.returnValue({center: {longitude: 0, latitude: 0}, zoom: 0, type: 'centerAndZoom'});
+    spyOn(mapService, 'initializeMap').and.resolveTo();
+    store.overrideSelector(mapFeature.selectLoadingState, 'loading');
+    store.overrideSelector(mapFeature.selectMapsState, {center: {longitude: 0, latitude: 0}, zoom: 0, loadingState: 'loading'});
+    actions$ = of(mapActions.loadMap());
+
+    initializeMap(actions$, store, mapService).subscribe((action) => {
+      expect(action).toEqual(mapActions.setMapAsLoaded());
+      expect(mapService.createInitialMapViewport).toHaveBeenCalledTimes(1);
+      expect(mapService.initializeMap).toHaveBeenCalledTimes(1);
+      done();
+    });
+  });
+
+  it('should not call the service if the map is already loaded', (done: DoneFn) => {
+    spyOn(mapService, 'initializeMap').and.resolveTo();
+    store.overrideSelector(mapFeature.selectLoadingState, 'loaded');
+    actions$ = of(mapActions.loadMap());
+
+    initializeMap(actions$, store, mapService).subscribe({
+      complete: () => {
+        expect(mapService.initializeMap).not.toHaveBeenCalled();
+        done();
+      },
+    });
+  });
+
+  it('should throw a MapError after dispatching setMapLoadingError', (done: DoneFn) => {
+    const error = new Error('My cabbages!!!');
+    const expectedError = new MapError(error);
+
+    actions$ = of(mapActions.setMapLoadingError({error}));
+    failLoadingMap(actions$)
+      .pipe(
+        catchError((caughtError: unknown) => {
+          OpendataExplorerRuntimeErrorTestUtil.expectToDeepEqual(caughtError, expectedError);
+          done();
+          return EMPTY;
+        }),
+      )
+      .subscribe();
+  });
+
+  it('should remove the map when mapActions.resetState is dispatched', (done) => {
+    spyOn(mapService, 'removeMap');
+    actions$ = of(mapActions.resetState());
+    removeMap(actions$, mapService).subscribe(() => {
+      expect(mapService.removeMap).toHaveBeenCalledOnceWith();
+      done();
+    });
+  });
+
+  it('should add stations to the map when mapActions.setMapAsLoaded is dispatched', (done) => {
+    spyOn(mapService, 'addStationsToMap');
     const stations: Station[] = [{id: '1', name: 'Station 1', coordinates: {longitude: 0, latitude: 0}}];
-    actions$ = of(stationActions.setLoadedStations({stations, measurementDataType: collectionConfig.defaultMeasurementDataType}));
-    addStationsToMap(actions$, mapService).subscribe(() => {
+    store.overrideSelector(mapFeature.selectLoadingState, 'loaded');
+    store.overrideSelector(selectCurrentStationState, {stations, loadingState: 'loaded'});
+    actions$ = of(mapActions.setMapAsLoaded());
+    addStationsToMap(actions$, store, mapService).subscribe(() => {
       expect(mapService.addStationsToMap).toHaveBeenCalledOnceWith(stations);
       done();
     });
   });
 
-  it('should filter stations on the map when formActions.setSelectedParameters is dispatched', (done) => {
+  it('should not add stations to the map when mapActions.setMapAsLoaded is dispatched while the map is not loaded yet', (done) => {
+    spyOn(mapService, 'addStationsToMap');
     const stations: Station[] = [{id: '1', name: 'Station 1', coordinates: {longitude: 0, latitude: 0}}];
+    store.overrideSelector(mapFeature.selectLoadingState, 'loading');
     store.overrideSelector(selectCurrentStationState, {stations, loadingState: 'loaded'});
-    actions$ = of(formActions.setSelectedParameters({parameterGroupId: 'test-group-id'}));
+    actions$ = of(mapActions.setMapAsLoaded());
+    addStationsToMap(actions$, store, mapService).subscribe({
+      complete: () => {
+        expect(mapService.addStationsToMap).not.toHaveBeenCalled();
+        done();
+      },
+    });
+  });
+
+  it('should not add stations to the map when mapActions.setMapAsLoaded is dispatched while the stations are not loaded yet', (done) => {
+    spyOn(mapService, 'addStationsToMap');
+    const stations: Station[] = [{id: '1', name: 'Station 1', coordinates: {longitude: 0, latitude: 0}}];
+    store.overrideSelector(mapFeature.selectLoadingState, 'loaded');
+    store.overrideSelector(selectCurrentStationState, {stations, loadingState: 'loading'});
+    actions$ = of(mapActions.setMapAsLoaded());
+    addStationsToMap(actions$, store, mapService).subscribe({
+      complete: () => {
+        expect(mapService.addStationsToMap).not.toHaveBeenCalled();
+        done();
+      },
+    });
+  });
+
+  it('should filter stations on the map when mapActions.setMapAsLoaded is dispatched', (done) => {
+    spyOn(mapService, 'filterStationsOnMap');
+    const stationIds: string[] = ['1', '2'];
+    store.overrideSelector(mapFeature.selectLoadingState, 'loaded');
+    store.overrideSelector(selectStationIdsFilteredBySelectedParameterGroups, stationIds);
+    actions$ = of(mapActions.setMapAsLoaded());
     filterStationsOnMap(actions$, store, mapService).subscribe(() => {
-      expect(mapService.filterStationsOnMap).toHaveBeenCalledOnceWith(stations);
+      expect(mapService.filterStationsOnMap).toHaveBeenCalledOnceWith(stationIds);
       done();
     });
   });

--- a/src/app/state/map/effects/map.effects.spec.ts
+++ b/src/app/state/map/effects/map.effects.spec.ts
@@ -4,7 +4,7 @@ import {Action} from '@ngrx/store';
 import {MockStore, provideMockStore} from '@ngrx/store/testing';
 import {catchError, EMPTY, Observable, of} from 'rxjs';
 import {MapService} from '../../../map/services/map.service';
-import {MapError} from '../../../shared/errors/map.error';
+import {MapLoadError} from '../../../shared/errors/map.error';
 import {Station} from '../../../shared/models/station';
 import {OpendataExplorerRuntimeErrorTestUtil} from '../../../shared/testing/utils/opendata-explorer-runtime-error-test.util';
 import {selectCurrentStationState, selectStationIdsFilteredBySelectedParameterGroups} from '../../stations/selectors/station.selector';
@@ -32,7 +32,6 @@ describe('MapEffects', () => {
   it('should dispatch the setMapAsLoaded action after successfully loading map using the action loadMap', (done: DoneFn) => {
     spyOn(mapService, 'createInitialMapViewport').and.returnValue({center: {longitude: 0, latitude: 0}, zoom: 0, type: 'centerAndZoom'});
     spyOn(mapService, 'initializeMap').and.resolveTo();
-    store.overrideSelector(mapFeature.selectLoadingState, 'loading');
     store.overrideSelector(mapFeature.selectMapsState, {center: {longitude: 0, latitude: 0}, zoom: 0, loadingState: 'loading'});
     actions$ = of(mapActions.loadMap());
 
@@ -59,7 +58,7 @@ describe('MapEffects', () => {
 
   it('should throw a MapError after dispatching setMapLoadingError', (done: DoneFn) => {
     const error = new Error('My cabbages!!!');
-    const expectedError = new MapError(error);
+    const expectedError = new MapLoadError(error);
 
     actions$ = of(mapActions.setMapLoadingError({error}));
     failLoadingMap(actions$)

--- a/src/app/state/map/effects/map.effects.ts
+++ b/src/app/state/map/effects/map.effects.ts
@@ -2,17 +2,67 @@ import {inject} from '@angular/core';
 import {Actions, createEffect, ofType} from '@ngrx/effects';
 import {concatLatestFrom} from '@ngrx/operators';
 import {Store} from '@ngrx/store';
-import {tap} from 'rxjs';
+import {catchError, filter, from, map, of, switchMap, tap} from 'rxjs';
 import {MapService} from '../../../map/services/map.service';
+import {mapConfig} from '../../../shared/configs/map.config';
+import {MapError} from '../../../shared/errors/map.error';
+import {collectionActions} from '../../collection/actions/collection.action';
 import {formActions} from '../../form/actions/form.actions';
 import {stationActions} from '../../stations/actions/station.action';
-import {selectCurrentStationState} from '../../stations/selectors/station.selector';
+import {selectCurrentStationState, selectStationIdsFilteredBySelectedParameterGroups} from '../../stations/selectors/station.selector';
+import {mapActions} from '../actions/map.action';
+import {mapFeature} from '../reducers/map.reducer';
 
-export const addStationsToMap = createEffect(
+export const initializeMap = createEffect(
+  (actions$ = inject(Actions), store = inject(Store), mapService = inject(MapService)) => {
+    return actions$.pipe(
+      ofType(mapActions.loadMap),
+      concatLatestFrom(() => store.select(mapFeature.selectLoadingState)),
+      filter(([, loadingState]) => loadingState !== 'loaded'),
+      concatLatestFrom(() => store.select(mapFeature.selectMapsState)),
+      map(([, {center, zoom}]) => mapService.createInitialMapViewport(zoom, center, mapConfig)),
+      switchMap((initialMapViewport) =>
+        from(mapService.initializeMap(mapConfig, initialMapViewport)).pipe(
+          map(() => mapActions.setMapAsLoaded()),
+          catchError((error: unknown) => of(mapActions.setMapLoadingError({error}))),
+        ),
+      ),
+    );
+  },
+  {functional: true},
+);
+
+export const failLoadingMap = createEffect(
+  (actions$ = inject(Actions)) => {
+    return actions$.pipe(
+      ofType(mapActions.setMapLoadingError),
+      tap(({error}) => {
+        throw new MapError(error);
+      }),
+    );
+  },
+  {functional: true, dispatch: false},
+);
+
+export const removeMap = createEffect(
   (actions$ = inject(Actions), mapService = inject(MapService)) => {
     return actions$.pipe(
-      ofType(stationActions.setLoadedStations),
-      tap(({stations}) => mapService.addStationsToMap(stations)),
+      ofType(mapActions.resetState),
+      tap(() => mapService.removeMap()),
+    );
+  },
+  {functional: true, dispatch: false},
+);
+
+export const addStationsToMap = createEffect(
+  (actions$ = inject(Actions), store = inject(Store), mapService = inject(MapService)) => {
+    return actions$.pipe(
+      ofType(stationActions.setLoadedStations, mapActions.setMapAsLoaded, collectionActions.loadCollections),
+      concatLatestFrom(() => [store.select(mapFeature.selectLoadingState), store.select(selectCurrentStationState)]),
+      filter(
+        ([, mapLoadingState, {loadingState: stationsLoadingState}]) => mapLoadingState === 'loaded' && stationsLoadingState === 'loaded',
+      ),
+      tap(([, , {stations}]) => mapService.addStationsToMap(stations)),
     );
   },
   {functional: true, dispatch: false},
@@ -21,10 +71,11 @@ export const addStationsToMap = createEffect(
 export const filterStationsOnMap = createEffect(
   (actions$ = inject(Actions), store = inject(Store), mapService = inject(MapService)) => {
     return actions$.pipe(
-      ofType(formActions.setSelectedParameters),
-      // TODO the following selector has to be replaced with one that returns stations filtered by the current parameter group selection
-      concatLatestFrom(() => store.select(selectCurrentStationState)),
-      tap(([, stationState]) => mapService.filterStationsOnMap(stationState.stations)),
+      ofType(formActions.setSelectedParameters, mapActions.setMapAsLoaded),
+      concatLatestFrom(() => store.select(mapFeature.selectLoadingState)),
+      filter(([, loadingState]) => loadingState === 'loaded'),
+      concatLatestFrom(() => store.select(selectStationIdsFilteredBySelectedParameterGroups)),
+      tap(([, stationIds]) => mapService.filterStationsOnMap(stationIds)),
     );
   },
   {functional: true, dispatch: false},

--- a/src/app/state/map/effects/map.effects.ts
+++ b/src/app/state/map/effects/map.effects.ts
@@ -5,7 +5,7 @@ import {Store} from '@ngrx/store';
 import {catchError, filter, from, map, of, switchMap, tap} from 'rxjs';
 import {MapService} from '../../../map/services/map.service';
 import {mapConfig} from '../../../shared/configs/map.config';
-import {MapError} from '../../../shared/errors/map.error';
+import {MapLoadError} from '../../../shared/errors/map.error';
 import {collectionActions} from '../../collection/actions/collection.action';
 import {formActions} from '../../form/actions/form.actions';
 import {stationActions} from '../../stations/actions/station.action';
@@ -37,7 +37,7 @@ export const failLoadingMap = createEffect(
     return actions$.pipe(
       ofType(mapActions.setMapLoadingError),
       tap(({error}) => {
-        throw new MapError(error);
+        throw new MapLoadError(error);
       }),
     );
   },

--- a/src/app/state/map/reducers/map.reducer.spec.ts
+++ b/src/app/state/map/reducers/map.reducer.spec.ts
@@ -6,7 +6,7 @@ describe('Map Reducer', () => {
   let state: MapState;
 
   beforeEach(() => {
-    state = initialState;
+    state = structuredClone(initialState);
   });
 
   it('should set loadingState to loading when loadMap is dispatched and loading state is currently not loaded', () => {

--- a/src/app/state/map/reducers/map.reducer.spec.ts
+++ b/src/app/state/map/reducers/map.reducer.spec.ts
@@ -1,0 +1,64 @@
+import {mapActions} from '../actions/map.action';
+import {MapState} from '../states/map.state';
+import {initialState, mapFeature} from './map.reducer';
+
+describe('Map Reducer', () => {
+  let state: MapState;
+
+  beforeEach(() => {
+    state = initialState;
+  });
+
+  it('should set loadingState to loading when loadMap is dispatched and loading state is currently not loaded', () => {
+    state = {...state, loadingState: 'error'};
+    const action = mapActions.loadMap();
+    const result = mapFeature.reducer(state, action);
+
+    expect(result).toEqual({...state, loadingState: 'loading'});
+  });
+
+  it('should not change loadingState if it is already loaded when loadMap is dispatched', () => {
+    state = {...state, loadingState: 'loaded'};
+    const action = mapActions.loadMap();
+    const result = mapFeature.reducer(state, action);
+
+    expect(result).toEqual({...state, loadingState: 'loaded'});
+  });
+
+  it('should loadingState to loaded when setMapAsLoaded is dispatched', () => {
+    const action = mapActions.setMapAsLoaded();
+    const result = mapFeature.reducer(state, action);
+
+    expect(result).toEqual({...state, loadingState: 'loaded'});
+  });
+
+  it('should reset to initialState and set loadingState to error when setMapLoadingError is dispatched', () => {
+    state = {...state, zoom: 5, center: {latitude: 0, longitude: 0}};
+    const action = mapActions.setMapLoadingError({});
+    const result = mapFeature.reducer(state, action);
+
+    expect(result).toEqual({...initialState, loadingState: 'error'});
+  });
+
+  it('should reset to initialState when resetState is dispatched', () => {
+    state = {loadingState: 'loading', zoom: 5, center: {latitude: 0, longitude: 0}};
+    const action = mapActions.resetState();
+    const result = mapFeature.reducer(state, action);
+
+    expect(result).toEqual(initialState);
+  });
+
+  it('should set zoom when setZoom is dispatched', () => {
+    const action = mapActions.setZoom({zoom: 5});
+    const result = mapFeature.reducer(state, action);
+
+    expect(result).toEqual({...state, zoom: 5});
+  });
+
+  it('should set center when setCenter is dispatched', () => {
+    const action = mapActions.setCenter({center: {latitude: 0, longitude: 0}});
+    const result = mapFeature.reducer(state, action);
+
+    expect(result).toEqual({...state, center: {latitude: 0, longitude: 0}});
+  });
+});

--- a/src/app/state/map/reducers/map.reducer.ts
+++ b/src/app/state/map/reducers/map.reducer.ts
@@ -1,0 +1,59 @@
+import {createFeature, createReducer, on} from '@ngrx/store';
+import {mapActions} from '../actions/map.action';
+import {MapState} from '../states/map.state';
+
+export const mapFeatureKey = 'maps';
+
+export const initialState: MapState = {
+  loadingState: undefined,
+  zoom: undefined,
+  center: undefined,
+};
+
+export const mapFeature = createFeature({
+  name: mapFeatureKey,
+  reducer: createReducer(
+    initialState,
+    on(
+      mapActions.loadMap,
+      (state): MapState => ({
+        ...state,
+        loadingState: state.loadingState !== 'loaded' ? 'loading' : state.loadingState,
+      }),
+    ),
+    on(
+      mapActions.setMapAsLoaded,
+      (state): MapState => ({
+        ...state,
+        loadingState: 'loaded',
+      }),
+    ),
+    on(
+      mapActions.setMapLoadingError,
+      (): MapState => ({
+        ...initialState,
+        loadingState: 'error',
+      }),
+    ),
+    on(
+      mapActions.resetState,
+      (): MapState => ({
+        ...initialState,
+      }),
+    ),
+    on(
+      mapActions.setZoom,
+      (state, {zoom}): MapState => ({
+        ...state,
+        zoom,
+      }),
+    ),
+    on(
+      mapActions.setCenter,
+      (state, {center}): MapState => ({
+        ...state,
+        center,
+      }),
+    ),
+  ),
+});

--- a/src/app/state/map/states/map.state.ts
+++ b/src/app/state/map/states/map.state.ts
@@ -1,0 +1,7 @@
+import {Coordinates} from '../../../shared/models/coordinates';
+import {LoadableState} from '../../../shared/models/loadable-state';
+
+export interface MapState extends LoadableState {
+  zoom: number | undefined;
+  center: Coordinates | undefined;
+}

--- a/src/app/state/stations/selectors/station.selector.spec.ts
+++ b/src/app/state/stations/selectors/station.selector.spec.ts
@@ -1,6 +1,6 @@
 import {ParameterGroupStationMapping} from '../../../shared/models/parameter-group-station-mapping';
 import {Station} from '../../../shared/models/station';
-import {selectStationsFilteredByParameterGroups} from './station.selector';
+import {selectStationIdsFilteredBySelectedParameterGroups} from './station.selector';
 
 describe('Station Selectors', () => {
   describe('selectStationsFilteredByParameterGroups', () => {
@@ -21,13 +21,13 @@ describe('Station Selectors', () => {
         {parameterGroupId: 'groupId3', stationId: stationOne.id},
       ];
 
-      const result = selectStationsFilteredByParameterGroups.projector(
+      const result = selectStationIdsFilteredBySelectedParameterGroups.projector(
         {stations, loadingState: 'loaded'},
         selectedParameterGroupId,
         parameterGroupStationMappings,
       );
 
-      expect(result).toEqual(jasmine.arrayWithExactContents([stationOne, stationTwo]));
+      expect(result).toEqual(jasmine.arrayWithExactContents([stationOne.id, stationTwo.id]));
     });
 
     it('should return an empty list if no stations are found', () => {
@@ -37,7 +37,7 @@ describe('Station Selectors', () => {
         {parameterGroupId: 'groupId1', stationId: 'nonExistingStationId'},
       ];
 
-      const result = selectStationsFilteredByParameterGroups.projector(
+      const result = selectStationIdsFilteredBySelectedParameterGroups.projector(
         {stations, loadingState: 'loaded'},
         selectedParameterGroupId,
         parameterGroupStationMappings,
@@ -51,7 +51,7 @@ describe('Station Selectors', () => {
       const selectedParameterGroupId = 'groupId1';
       const parameterGroupStationMappings: ParameterGroupStationMapping[] = [];
 
-      const result = selectStationsFilteredByParameterGroups.projector(
+      const result = selectStationIdsFilteredBySelectedParameterGroups.projector(
         {stations, loadingState: 'loaded'},
         selectedParameterGroupId,
         parameterGroupStationMappings,
@@ -65,13 +65,13 @@ describe('Station Selectors', () => {
       const selectedParameterGroupId = null;
       const parameterGroupStationMappings: ParameterGroupStationMapping[] = [{parameterGroupId: 'groupId1', stationId: stationOne.id}];
 
-      const result = selectStationsFilteredByParameterGroups.projector(
+      const result = selectStationIdsFilteredBySelectedParameterGroups.projector(
         {stations, loadingState: 'loaded'},
         selectedParameterGroupId,
         parameterGroupStationMappings,
       );
 
-      expect(result).toEqual(jasmine.arrayWithExactContents([stationOne, stationTwo, stationThree]));
+      expect(result).toEqual(jasmine.arrayWithExactContents([stationOne.id, stationTwo.id, stationThree.id]));
     });
   });
 });

--- a/src/app/state/stations/selectors/station.selector.ts
+++ b/src/app/state/stations/selectors/station.selector.ts
@@ -1,5 +1,4 @@
 import {createSelector} from '@ngrx/store';
-import {Station} from '../../../shared/models/station';
 import {formFeature} from '../../form/reducers/form.reducer';
 import {selectParameterGroupStationMappings} from '../../parameter-station-mapping/selectors/parameter-group-station-mapping.selector';
 import {stationFeature} from '../reducers/station.reducer';
@@ -11,18 +10,18 @@ export const selectCurrentStationState = createSelector(
   (stationState, measurementDataType): StationStateEntry => stationState[measurementDataType],
 );
 
-export const selectStationsFilteredByParameterGroups = createSelector(
+export const selectStationIdsFilteredBySelectedParameterGroups = createSelector(
   selectCurrentStationState,
   formFeature.selectSelectedParameterGroupId,
   selectParameterGroupStationMappings,
-  (stationState, parameterGroupId, parameterGroupStationMappings): Station[] => {
+  (stationState, parameterGroupId, parameterGroupStationMappings): string[] => {
     if (!parameterGroupId) {
-      return stationState.stations;
+      return stationState.stations.map((station) => station.id);
     }
 
     const matchingStationIds = parameterGroupStationMappings
       .filter((mapping) => mapping.parameterGroupId === parameterGroupId)
       .map((mapping) => mapping.stationId);
-    return stationState.stations.filter((station) => matchingStationIds.includes(station.id));
+    return stationState.stations.filter((station) => matchingStationIds.includes(station.id)).map((station) => station.id);
   },
 );


### PR DESCRIPTION
The state enables us to have more control over the map logic flow, especially when involving other states like the station state. Therefore, we add the current `LoadingState` as well as all parameters that are necessary for the URL parameters (`zoom`, `center`) to the state.

The logic flow to create and initialize the map works as follows:
1. `MapContainerComponent.ngAfterViewInit` calls the `MapService` to create the map (`createMap()`). No stations or even the style gets added. Just the basic map. After this (synchronous) creation it dispatches the `MapActions.loadMap`. Now the store gets involved.
2. There is an effect listening for `MapActions.loadMap`. This effect calls the `MapService` to asynchronously initialize the existing map (`initializeMap()`). Now the styles get loaded, the zoom and center parameter used and everything for the map prepared except the stations or filters.
3. Afterwards this either succeeds (`MapActions.setMapAsLoaded`) or fails (`MapActions.setMapLoadingError`)
4. If it succeeds then the stations and filters will be applied. If the neither of those are fully loaded yet then nothing happens. As soon as the stations are set the effect gets triggered again.