### PR TITLE
Add interaktive controls for the map #34

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -31,7 +31,11 @@
                 "input": "public"
               }
             ],
-            "styles": ["@angular/material/prebuilt-themes/azure-blue.css", "src/styles.scss"],
+            "styles": [
+              "@angular/material/prebuilt-themes/azure-blue.css",
+              "src/styles.scss",
+              "./node_modules/maplibre-gl/dist/maplibre-gl.css"
+            ],
             "scripts": []
           },
           "configurations": {

--- a/src/app/data-selection-form/data-selection-form.component.html
+++ b/src/app/data-selection-form/data-selection-form.component.html
@@ -20,12 +20,12 @@
   </div>
 
   <mat-vertical-stepper [linear]="true" #stepper>
-    <mat-step [completed]="(selectedParameterGroup$ | async) !== null">
+    <mat-step [completed]="(selectSelectedStationId$ | async) !== null">
       <ng-template matStepLabel>{{ t('form.stepper.station.label') }}</ng-template>
       <app-parameter-list></app-parameter-list>
       <app-map-container class="map-container"></app-map-container>
       <div>
-        <button mat-button matStepperNext type="button" [disabled]="(selectedParameterGroup$ | async) === null">
+        <button mat-button matStepperNext type="button" [disabled]="(selectSelectedStationId$ | async) === null">
           {{ t('form.stepper.next') }}
         </button>
       </div>

--- a/src/app/data-selection-form/data-selection-form.component.ts
+++ b/src/app/data-selection-form/data-selection-form.component.ts
@@ -41,7 +41,7 @@ export class DataSelectionFormComponent implements OnInit {
   private readonly translocoService = inject(TranslocoService);
   private readonly store = inject(Store);
 
-  protected readonly selectedParameterGroup$ = this.store.select(formFeature.selectSelectedParameterGroupId);
+  protected readonly selectSelectedStationId$ = this.store.select(formFeature.selectSelectedStationId);
   protected readonly selectedSelectedDataInterval$ = this.store.select(formFeature.selectSelectedDataInterval);
   protected readonly selectedSelectedTimeRange$ = this.store.select(formFeature.selectSelectedTimeRange);
   protected readonly selectedMeasurementDataType$ = this.store.select(formFeature.selectSelectedMeasurementDataType);

--- a/src/app/map/components/map-container/map-container.component.html
+++ b/src/app/map/components/map-container/map-container.component.html
@@ -1,1 +1,8 @@
-<div #map class="map-container"></div>
+<div class="map-container">
+  <div #map class="map"></div>
+  <div class="map-controls">
+    <button mat-flat-button color="primary" (click)="zoomIn()"><mat-icon>add</mat-icon></button>
+    <button mat-flat-button color="primary" (click)="zoomOut()"><mat-icon>remove</mat-icon></button>
+    <button mat-flat-button color="primary" (click)="resetExtent()"><mat-icon>home</mat-icon></button>
+  </div>
+</div>

--- a/src/app/map/components/map-container/map-container.component.scss
+++ b/src/app/map/components/map-container/map-container.component.scss
@@ -1,5 +1,18 @@
 .map-container {
-  flex-grow: 1;
+  position: relative;
   height: 300px;
-  overflow: hidden;
+  min-width: 600px;
+
+  .map {
+    height: 100%;
+    width: 100%;
+  }
+
+  .map-controls {
+    position: absolute;
+    bottom: 40px;
+    right: 0;
+    display: flex;
+    flex-direction: column;
+  }
 }

--- a/src/app/map/components/map-container/map-container.component.ts
+++ b/src/app/map/components/map-container/map-container.component.ts
@@ -1,4 +1,6 @@
 import {AfterViewInit, Component, ElementRef, inject, OnDestroy, ViewChild} from '@angular/core';
+import {MatButton} from '@angular/material/button';
+import {MatIcon} from '@angular/material/icon';
 import {Store} from '@ngrx/store';
 import {mapConfig} from '../../../shared/configs/map.config';
 import {mapActions} from '../../../state/map/actions/map.action';
@@ -7,13 +9,14 @@ import {MapService} from '../../services/map.service';
 @Component({
   selector: 'app-map-container',
   standalone: true,
-  imports: [],
+  imports: [MatButton, MatIcon],
   templateUrl: './map-container.component.html',
   styleUrl: './map-container.component.scss',
 })
 export class MapContainerComponent implements AfterViewInit, OnDestroy {
   private readonly store = inject(Store);
   private readonly mapService = inject(MapService);
+
   @ViewChild('map', {static: true}) private readonly openLayerMapElementRef!: ElementRef<HTMLDivElement>;
 
   public ngAfterViewInit(): void {
@@ -23,5 +26,17 @@ export class MapContainerComponent implements AfterViewInit, OnDestroy {
 
   public ngOnDestroy(): void {
     this.store.dispatch(mapActions.resetState());
+  }
+
+  protected zoomIn(): void {
+    this.mapService.zoomIn();
+  }
+
+  protected zoomOut(): void {
+    this.mapService.zoomOut();
+  }
+
+  protected resetExtent(): void {
+    this.mapService.resetExtent(mapConfig);
   }
 }

--- a/src/app/map/models/feature-property.ts
+++ b/src/app/map/models/feature-property.ts
@@ -1,3 +1,0 @@
-import {Station} from '../../shared/models/station';
-
-export type FeatureProperty = Pick<Station, 'id' | 'name'>;

--- a/src/app/map/models/feature-property.ts
+++ b/src/app/map/models/feature-property.ts
@@ -1,0 +1,3 @@
+import {Station} from '../../shared/models/station';
+
+export type FeatureProperty = Pick<Station, 'id' | 'name'>;

--- a/src/app/map/services/map.service.spec.ts
+++ b/src/app/map/services/map.service.spec.ts
@@ -98,7 +98,6 @@ describe('MapService', () => {
       const styleSpecification = setStyleSpy.calls.first().args[0] as StyleSpecification;
       expect(styleSpecification.layers.length).toEqual(1);
       expect(styleSpecification.layers[0].id).toEqual('background');
-      expect(map.on).toHaveBeenCalledTimes(2);
       expect(map.on).toHaveBeenCalledWith('zoom', jasmine.any(Function));
       expect(map.on).toHaveBeenCalledWith('move', jasmine.any(Function));
     });

--- a/src/app/map/services/map.service.ts
+++ b/src/app/map/services/map.service.ts
@@ -19,7 +19,6 @@ import {MapConfig} from '../../shared/models/configs/map-config';
 import {Coordinates} from '../../shared/models/coordinates';
 import {Station} from '../../shared/models/station';
 import {mapActions} from '../../state/map/actions/map.action';
-import {FeatureProperty} from '../models/feature-property';
 import {MapViewport} from '../models/map-viewport';
 
 type MapLayerClickEvent = MapMouseEvent & {features?: MapGeoJSONFeature[]} & object;
@@ -113,7 +112,7 @@ export class MapService {
           properties: {
             id: station.id,
             name: station.name,
-          } satisfies FeatureProperty,
+          } satisfies Pick<Station, 'id' | 'name'>,
         })),
       },
       // this is a workaround to get IDs of type `string` working (otherwise only `number` is accepted)

--- a/src/app/shared/configs/map.config.ts
+++ b/src/app/shared/configs/map.config.ts
@@ -13,4 +13,5 @@ export const mapConfig = {
     center: {longitude: 8.231974, latitude: 46.818187},
     zoom: 6,
   },
+  minZoom: 6,
 } as const satisfies MapConfig;

--- a/src/app/shared/models/configs/map-config.ts
+++ b/src/app/shared/models/configs/map-config.ts
@@ -5,4 +5,5 @@ export interface MapConfig {
   enableRotation: boolean;
   defaultBoundingBox: BoundingBox;
   defaultZoomAndCenter: CenterAndZoom;
+  minZoom: number;
 }

--- a/src/app/state/form/actions/form.actions.ts
+++ b/src/app/state/form/actions/form.actions.ts
@@ -7,6 +7,7 @@ export const formActions = createActionGroup({
   source: 'Form',
   events: {
     'Set selected parameters': props<{parameterGroupId: string | null}>(),
+    'Set selected station id': props<{stationId: string | null}>(),
     'Set selected dataInterval': props<{dataInterval: DataInterval}>(),
     'Set selected time range': props<{timeRange: TimeRange}>(),
     'Set selected measurement data type': props<{measurementDataType: MeasurementDataType}>(),

--- a/src/app/state/form/effects/form.effects.spec.ts
+++ b/src/app/state/form/effects/form.effects.spec.ts
@@ -1,3 +1,4 @@
+import {provideHttpClient} from '@angular/common/http';
 import {TestBed} from '@angular/core/testing';
 import {Action} from '@ngrx/store';
 import {MockStore, provideMockStore} from '@ngrx/store/testing';
@@ -5,7 +6,7 @@ import {Observable, of} from 'rxjs';
 import {collectionConfig} from '../../../shared/configs/collections.config';
 import {collectionActions} from '../../collection/actions/collection.action';
 import {formActions} from '../actions/form.actions';
-import {loadCollectionsForSelectedMeasurementDataType} from './form.effects';
+import {loadCollectionsForSelectedMeasurementDataType, removeStationSelectionOnSelectedParameterChange} from './form.effects';
 
 describe('FormEffects', () => {
   const measurementDataType = collectionConfig.defaultMeasurementDataType;
@@ -16,7 +17,7 @@ describe('FormEffects', () => {
   beforeEach(() => {
     actions$ = new Observable<Action>();
     TestBed.configureTestingModule({
-      providers: [provideMockStore()],
+      providers: [provideMockStore(), provideHttpClient()],
     });
     store = TestBed.inject(MockStore);
   });
@@ -32,6 +33,14 @@ describe('FormEffects', () => {
       expect(action).toEqual(
         collectionActions.loadCollections({collections: collectionConfig.collections[measurementDataType], measurementDataType}),
       );
+      done();
+    });
+  });
+
+  it('should dispatch the setSelectedStationId action with `null` when the selected parameter changes', (done: DoneFn) => {
+    actions$ = of(formActions.setSelectedParameters({parameterGroupId: 'newParameterGroupId'}));
+    removeStationSelectionOnSelectedParameterChange(actions$).subscribe((action) => {
+      expect(action).toEqual(formActions.setSelectedStationId({stationId: null}));
       done();
     });
   });

--- a/src/app/state/form/effects/form.effects.ts
+++ b/src/app/state/form/effects/form.effects.ts
@@ -16,3 +16,13 @@ export const loadCollectionsForSelectedMeasurementDataType = createEffect(
   },
   {functional: true},
 );
+
+export const removeStationSelectionOnSelectedParameterChange = createEffect(
+  (actions$ = inject(Actions)) => {
+    return actions$.pipe(
+      ofType(formActions.setSelectedParameters),
+      map(() => formActions.setSelectedStationId({stationId: null})),
+    );
+  },
+  {functional: true},
+);

--- a/src/app/state/form/reducers/form.reducer.spec.ts
+++ b/src/app/state/form/reducers/form.reducer.spec.ts
@@ -6,36 +6,73 @@ describe('Parameter Reducer', () => {
   let state: FormState;
 
   beforeEach(() => {
-    state = structuredClone(initialState);
-  });
-
-  // TODO: Add more tests after merging PR #19
-
-  it('should reset selection of upcoming steps if parameter is selected', () => {
-    state = {...state, selectedParameterGroupId: 'A', selectedDataInterval: 'daily', selectedTimeRange: 'all-time'};
-    const action = formActions.setSelectedParameters({parameterGroupId: 'test'});
-    const result = formFeature.reducer(state, action);
-
-    expect(result.selectedParameterGroupId).toBe('test');
-    expect(result.selectedDataInterval).toBe(null);
-    expect(result.selectedTimeRange).toBe(null);
-  });
-
-  it('should reset selection of upcoming steps if dataInterval is selected', () => {
-    state = {...state, selectedParameterGroupId: 'A', selectedDataInterval: 'daily', selectedTimeRange: 'all-time'};
-    const action = formActions.setSelectedDataInterval({dataInterval: 'monthly'});
-    const result = formFeature.reducer(state, action);
-
-    expect(result.selectedParameterGroupId).toBe('A');
-    expect(result.selectedDataInterval).toBe('monthly');
-    expect(result.selectedTimeRange).toBe(null);
+    state = {
+      selectedMeasurementDataType: 'normal',
+      selectedParameterGroupId: 'A',
+      selectedStationId: 'ALT',
+      selectedDataInterval: 'daily',
+      selectedTimeRange: 'all-time',
+    };
   });
 
   it('should reset the form state when a measurement data type is selected', () => {
-    state = {...state, selectedParameterGroupId: 'A', selectedDataInterval: 'daily', selectedTimeRange: 'all-time'};
     const action = formActions.setSelectedMeasurementDataType({measurementDataType: 'homogenous'});
+
     const result = formFeature.reducer(state, action);
 
     expect(result).toEqual({...initialState, selectedMeasurementDataType: 'homogenous'});
+  });
+
+  it('should reset selection of upcoming steps if parameter group ID is selected', () => {
+    const action = formActions.setSelectedParameters({parameterGroupId: 'test'});
+
+    const result = formFeature.reducer(state, action);
+
+    expect(result).toEqual({
+      ...initialState,
+      selectedMeasurementDataType: 'normal',
+      selectedParameterGroupId: 'test',
+    });
+  });
+
+  it('should reset selection of upcoming steps if station ID is selected', () => {
+    const action = formActions.setSelectedStationId({stationId: 'test'});
+
+    const result = formFeature.reducer(state, action);
+
+    expect(result).toEqual({
+      ...initialState,
+      selectedMeasurementDataType: 'normal',
+      selectedParameterGroupId: 'A',
+      selectedStationId: 'test',
+    });
+  });
+
+  it('should reset selection of upcoming steps if dataInterval is selected', () => {
+    const action = formActions.setSelectedDataInterval({dataInterval: 'monthly'});
+
+    const result = formFeature.reducer(state, action);
+
+    expect(result).toEqual({
+      ...initialState,
+      selectedMeasurementDataType: 'normal',
+      selectedParameterGroupId: 'A',
+      selectedStationId: 'ALT',
+      selectedDataInterval: 'monthly',
+    });
+  });
+
+  it('should just set time range if it is selected', () => {
+    const action = formActions.setSelectedTimeRange({timeRange: 'current-day'});
+
+    const result = formFeature.reducer(state, action);
+
+    expect(result).toEqual({
+      selectedMeasurementDataType: 'normal',
+      selectedParameterGroupId: 'A',
+      selectedStationId: 'ALT',
+      selectedDataInterval: 'daily',
+      selectedTimeRange: 'current-day',
+    });
   });
 });

--- a/src/app/state/form/reducers/form.reducer.spec.ts
+++ b/src/app/state/form/reducers/form.reducer.spec.ts
@@ -9,6 +9,8 @@ describe('Parameter Reducer', () => {
     state = structuredClone(initialState);
   });
 
+  // TODO: Add more tests after merging PR #19
+
   it('should reset selection of upcoming steps if parameter is selected', () => {
     state = {...state, selectedParameterGroupId: 'A', selectedDataInterval: 'daily', selectedTimeRange: 'all-time'};
     const action = formActions.setSelectedParameters({parameterGroupId: 'test'});

--- a/src/app/state/form/reducers/form.reducer.ts
+++ b/src/app/state/form/reducers/form.reducer.ts
@@ -6,17 +6,21 @@ import {FormState} from '../states/form.state';
 export const formFeatureKey = 'form';
 
 export const initialState: FormState = {
+  selectedMeasurementDataType: collectionConfig.defaultMeasurementDataType,
   selectedParameterGroupId: null,
   selectedStationId: null,
   selectedDataInterval: null,
   selectedTimeRange: null,
-  selectedMeasurementDataType: collectionConfig.defaultMeasurementDataType,
 };
 
 export const formFeature = createFeature({
   name: formFeatureKey,
   reducer: createReducer(
     initialState,
+    on(
+      formActions.setSelectedMeasurementDataType,
+      (_, {measurementDataType}): FormState => ({...initialState, selectedMeasurementDataType: measurementDataType}),
+    ),
     on(
       formActions.setSelectedParameters,
       (state, {parameterGroupId}): FormState => ({
@@ -50,10 +54,6 @@ export const formFeature = createFeature({
         ...state,
         selectedTimeRange: timeRange,
       }),
-    ),
-    on(
-      formActions.setSelectedMeasurementDataType,
-      (_, {measurementDataType}): FormState => ({...initialState, selectedMeasurementDataType: measurementDataType}),
     ),
   ),
 });

--- a/src/app/state/form/reducers/form.reducer.ts
+++ b/src/app/state/form/reducers/form.reducer.ts
@@ -7,6 +7,7 @@ export const formFeatureKey = 'form';
 
 export const initialState: FormState = {
   selectedParameterGroupId: null,
+  selectedStationId: null,
   selectedDataInterval: null,
   selectedTimeRange: null,
   selectedMeasurementDataType: collectionConfig.defaultMeasurementDataType,
@@ -18,9 +19,19 @@ export const formFeature = createFeature({
     initialState,
     on(
       formActions.setSelectedParameters,
-      (state, {parameterGroupId: parameterId}): FormState => ({
+      (state, {parameterGroupId}): FormState => ({
         ...state,
-        selectedParameterGroupId: parameterId,
+        selectedParameterGroupId: parameterGroupId,
+        selectedStationId: null,
+        selectedDataInterval: null,
+        selectedTimeRange: null,
+      }),
+    ),
+    on(
+      formActions.setSelectedStationId,
+      (state, {stationId}): FormState => ({
+        ...state,
+        selectedStationId: stationId,
         selectedDataInterval: null,
         selectedTimeRange: null,
       }),

--- a/src/app/state/form/states/form.state.ts
+++ b/src/app/state/form/states/form.state.ts
@@ -4,6 +4,7 @@ import {TimeRange} from '../../../shared/models/time-range';
 
 export interface FormState {
   selectedParameterGroupId: string | null;
+  selectedStationId: string | null;
   selectedDataInterval: DataInterval | null;
   selectedTimeRange: TimeRange | null;
   selectedMeasurementDataType: MeasurementDataType;

--- a/src/app/state/map/actions/map.action.ts
+++ b/src/app/state/map/actions/map.action.ts
@@ -11,5 +11,6 @@ export const mapActions = createActionGroup({
     'Reset state': emptyProps(),
     'Set zoom': props<{zoom: number}>(),
     'Set center': props<{center: Coordinates}>(),
+    'Toggle station selection': props<{stationId: string}>(),
   },
 });

--- a/src/app/state/map/effects/map.effects.spec.ts
+++ b/src/app/state/map/effects/map.effects.spec.ts
@@ -7,10 +7,20 @@ import {MapService} from '../../../map/services/map.service';
 import {MapLoadError} from '../../../shared/errors/map.error';
 import {Station} from '../../../shared/models/station';
 import {OpendataExplorerRuntimeErrorTestUtil} from '../../../shared/testing/utils/opendata-explorer-runtime-error-test.util';
+import {formActions} from '../../form/actions/form.actions';
+import {formFeature} from '../../form/reducers/form.reducer';
 import {selectCurrentStationState, selectStationIdsFilteredBySelectedParameterGroups} from '../../stations/selectors/station.selector';
 import {mapActions} from '../actions/map.action';
 import {mapFeature} from '../reducers/map.reducer';
-import {addStationsToMap, failLoadingMap, filterStationsOnMap, initializeMap, removeMap} from './map.effects';
+import {
+  addStationsToMap,
+  failLoadingMap,
+  filterStationsOnMap,
+  highlightSelectedStationOnMap,
+  initializeMap,
+  removeMap,
+  toggleStationSelection,
+} from './map.effects';
 
 describe('MapEffects', () => {
   let actions$: Observable<Action>;
@@ -129,6 +139,54 @@ describe('MapEffects', () => {
     actions$ = of(mapActions.setMapAsLoaded());
     filterStationsOnMap(actions$, store, mapService).subscribe(() => {
       expect(mapService.filterStationsOnMap).toHaveBeenCalledOnceWith(stationIds);
+      done();
+    });
+  });
+
+  it('should dispatch formActions.setSelectedStationId with an ID when mapActions.toggleStationSelection is dispatched with a new ID', (done) => {
+    const stationId = '1';
+    store.overrideSelector(formFeature.selectSelectedStationId, '2');
+    actions$ = of(mapActions.toggleStationSelection({stationId}));
+    toggleStationSelection(actions$, store).subscribe((action) => {
+      expect(action).toEqual(formActions.setSelectedStationId({stationId}));
+      done();
+    });
+  });
+
+  it('should dispatch formActions.setSelectedStationId with `null` when mapActions.toggleStationSelection is dispatched with an existing ID', (done) => {
+    const stationId = '1';
+    store.overrideSelector(formFeature.selectSelectedStationId, '1');
+    actions$ = of(mapActions.toggleStationSelection({stationId}));
+    toggleStationSelection(actions$, store).subscribe((action) => {
+      expect(action).toEqual(formActions.setSelectedStationId({stationId: null}));
+      done();
+    });
+  });
+
+  it('should highlight the selected station on the map when formActions.setSelectedStationId is dispatched with a new ID', (done) => {
+    spyOn(mapService, 'highlightStation');
+    spyOn(mapService, 'removeHighlight');
+    const stationId = '1';
+    store.overrideSelector(mapFeature.selectLoadingState, 'loaded');
+    store.overrideSelector(formFeature.selectSelectedStationId, stationId);
+    actions$ = of(formActions.setSelectedStationId({stationId}));
+    highlightSelectedStationOnMap(actions$, store, mapService).subscribe(() => {
+      expect(mapService.highlightStation).toHaveBeenCalledOnceWith(stationId);
+      expect(mapService.removeHighlight).not.toHaveBeenCalled();
+      done();
+    });
+  });
+
+  it('should remove any highlight on the map when formActions.setSelectedStationId is dispatched with `null`', (done) => {
+    spyOn(mapService, 'highlightStation');
+    spyOn(mapService, 'removeHighlight');
+    const stationId = null;
+    store.overrideSelector(mapFeature.selectLoadingState, 'loaded');
+    store.overrideSelector(formFeature.selectSelectedStationId, stationId);
+    actions$ = of(formActions.setSelectedStationId({stationId}));
+    highlightSelectedStationOnMap(actions$, store, mapService).subscribe(() => {
+      expect(mapService.highlightStation).not.toHaveBeenCalled();
+      expect(mapService.removeHighlight).toHaveBeenCalledOnceWith();
       done();
     });
   });

--- a/src/app/state/map/effects/map.effects.ts
+++ b/src/app/state/map/effects/map.effects.ts
@@ -8,6 +8,7 @@ import {mapConfig} from '../../../shared/configs/map.config';
 import {MapLoadError} from '../../../shared/errors/map.error';
 import {collectionActions} from '../../collection/actions/collection.action';
 import {formActions} from '../../form/actions/form.actions';
+import {formFeature} from '../../form/reducers/form.reducer';
 import {stationActions} from '../../stations/actions/station.action';
 import {selectCurrentStationState, selectStationIdsFilteredBySelectedParameterGroups} from '../../stations/selectors/station.selector';
 import {mapActions} from '../actions/map.action';
@@ -76,6 +77,42 @@ export const filterStationsOnMap = createEffect(
       filter(([, loadingState]) => loadingState === 'loaded'),
       concatLatestFrom(() => store.select(selectStationIdsFilteredBySelectedParameterGroups)),
       tap(([, stationIds]) => mapService.filterStationsOnMap(stationIds)),
+    );
+  },
+  {functional: true, dispatch: false},
+);
+
+export const toggleStationSelection = createEffect(
+  (actions$ = inject(Actions), store = inject(Store)) => {
+    return actions$.pipe(
+      ofType(mapActions.toggleStationSelection),
+      concatLatestFrom(() => store.select(formFeature.selectSelectedStationId)),
+      map(([{stationId}, selectedStationId]) => {
+        if (stationId === selectedStationId) {
+          return formActions.setSelectedStationId({stationId: null});
+        }
+        return formActions.setSelectedStationId({stationId});
+      }),
+    );
+  },
+  {functional: true},
+);
+
+export const highlightSelectedStationOnMap = createEffect(
+  (actions$ = inject(Actions), store = inject(Store), mapService = inject(MapService)) => {
+    return actions$.pipe(
+      ofType(formActions.setSelectedStationId, mapActions.setMapAsLoaded),
+      concatLatestFrom(() => store.select(mapFeature.selectLoadingState)),
+      filter(([, loadingState]) => loadingState === 'loaded'),
+      concatLatestFrom(() => store.select(formFeature.selectSelectedStationId)),
+      map(([_, selectedStationId]) => selectedStationId),
+      tap((selectedStationId) => {
+        if (selectedStationId) {
+          mapService.highlightStation(selectedStationId);
+        } else {
+          mapService.removeHighlight();
+        }
+      }),
     );
   },
   {functional: true, dispatch: false},


### PR DESCRIPTION
* **Enable click & highlight for stations**
The selected station ID is now also the trigger to unlock the next form part. (De-/)Selecting a parameter resets the station selection.
* **Add MapLibre css** (whoopsy 😅)
* **Add basic map controls**
  * Home
  * Zoom in
  * Zoom out
* **Rewrite form unit tests**
Now all form reducers are fully tested. Also they're now in the same order as they are within the stepper (measurement data type > parameter > station > ...).