### PR TITLE
Station search input field #58

### DIFF
--- a/public/i18n/de.json
+++ b/public/i18n/de.json
@@ -23,7 +23,9 @@
   "overview_file_size": "Missing value for 'overview_file_size'",
   "download-asset": "Missing value for 'download-asset'",
   "download-metadata": "Missing value for 'download-metadata'",
-  "station.load.error": "Missing value for 'station.load.error'",
   "parameter.load.error": "Fehler beim Laden der Parameter",
-  "parameter-station-mapping.load.error": "Missing value for 'parameter-station-mapping.load.error'"
+  "parameter-station-mapping.load.error": "Missing value for 'parameter-station-mapping.load.error'",
+  "station.name": "Station",
+  "station.load.error": "Missing value for 'station.load.error'",
+  "station.search.placeholder": "Station suchen"
 }

--- a/public/i18n/de.json
+++ b/public/i18n/de.json
@@ -10,11 +10,11 @@
   "form.stepper.time-range.label": "Missing value for 'form.stepper.time-range.label'",
   "form.stepper.overview.label": "Missing value for 'form.stepper.overview.label'",
   "form.stepper.download.label": "Missing value for 'form.stepper.download.label'",
-  "map.load.error": "Missing value for 'map.load.error'",
-  "map.not-initialized.error": "Missing value for 'map.not-initialized.error'",
   "now-time-interval": "Missing value for 'now-time-interval'",
   "recent-time-interval": "Missing value for 'recent-time-interval'",
   "historical-time-range-explanation": "Missing value for 'historical-time-range-explanation'",
+  "station.search.placeholder": "Station suchen",
+  "station.name": "Station",
   "overview_station_name": "Missing value for 'overview_station_name'",
   "overview_parameter_groups": "Missing value for 'overview_parameter_groups'",
   "overview_interval": "Missing value for 'overview_interval'",
@@ -23,9 +23,9 @@
   "overview_file_size": "Missing value for 'overview_file_size'",
   "download-asset": "Missing value for 'download-asset'",
   "download-metadata": "Missing value for 'download-metadata'",
+  "station.load.error": "Missing value for 'station.load.error'",
   "parameter.load.error": "Fehler beim Laden der Parameter",
   "parameter-station-mapping.load.error": "Missing value for 'parameter-station-mapping.load.error'",
-  "station.name": "Station",
-  "station.load.error": "Missing value for 'station.load.error'",
-  "station.search.placeholder": "Station suchen"
+  "map.load.error": "Missing value for 'map.load.error'",
+  "map.not-initialized.error": "Missing value for 'map.not-initialized.error'"
 }

--- a/public/i18n/en.json
+++ b/public/i18n/en.json
@@ -23,7 +23,9 @@
   "overview_file_size": "Missing value for 'overview_file_size'",
   "download-asset": "Missing value for 'download-asset'",
   "download-metadata": "Missing value for 'download-metadata'",
-  "station.load.error": "Missing value for 'station.load.error'",
   "parameter.load.error": "Error loading parameters",
-  "parameter-station-mapping.load.error": "Missing value for 'parameter-station-mapping.load.error'"
+  "parameter-station-mapping.load.error": "Missing value for 'parameter-station-mapping.load.error'",
+  "station.name": "Station",
+  "station.load.error": "Missing value for 'station.load.error'",
+  "station.search.placeholder": "Search station"
 }

--- a/public/i18n/en.json
+++ b/public/i18n/en.json
@@ -10,11 +10,11 @@
   "form.stepper.time-range.label": "Missing value for 'form.stepper.time-range.label'",
   "form.stepper.overview.label": "Missing value for 'form.stepper.overview.label'",
   "form.stepper.download.label": "Missing value for 'form.stepper.download.label'",
-  "map.load.error": "Missing value for 'map.load.error'",
-  "map.not-initialized.error": "Missing value for 'map.not-initialized.error'",
   "now-time-interval": "Missing value for 'now-time-interval'",
   "recent-time-interval": "Missing value for 'recent-time-interval'",
   "historical-time-range-explanation": "Missing value for 'historical-time-range-explanation'",
+  "station.search.placeholder": "Search station",
+  "station.name": "Station",
   "overview_station_name": "Missing value for 'overview_station_name'",
   "overview_parameter_groups": "Missing value for 'overview_parameter_groups'",
   "overview_interval": "Missing value for 'overview_interval'",
@@ -23,9 +23,9 @@
   "overview_file_size": "Missing value for 'overview_file_size'",
   "download-asset": "Missing value for 'download-asset'",
   "download-metadata": "Missing value for 'download-metadata'",
+  "station.load.error": "Missing value for 'station.load.error'",
   "parameter.load.error": "Error loading parameters",
   "parameter-station-mapping.load.error": "Missing value for 'parameter-station-mapping.load.error'",
-  "station.name": "Station",
-  "station.load.error": "Missing value for 'station.load.error'",
-  "station.search.placeholder": "Search station"
+  "map.load.error": "Missing value for 'map.load.error'",
+  "map.not-initialized.error": "Missing value for 'map.not-initialized.error'"
 }

--- a/public/i18n/fr.json
+++ b/public/i18n/fr.json
@@ -10,11 +10,11 @@
   "form.stepper.time-range.label": "Missing value for 'form.stepper.time-range.label'",
   "form.stepper.overview.label": "Missing value for 'form.stepper.overview.label'",
   "form.stepper.download.label": "Missing value for 'form.stepper.download.label'",
-  "map.load.error": "Missing value for 'map.load.error'",
-  "map.not-initialized.error": "Missing value for 'map.not-initialized.error'",
   "now-time-interval": "Missing value for 'now-time-interval'",
   "recent-time-interval": "Missing value for 'recent-time-interval'",
   "historical-time-range-explanation": "Missing value for 'historical-time-range-explanation'",
+  "station.search.placeholder": "Chercher une station",
+  "station.name": "Station",
   "overview_station_name": "Missing value for 'overview_station_name'",
   "overview_parameter_groups": "Missing value for 'overview_parameter_groups'",
   "overview_interval": "Missing value for 'overview_interval'",
@@ -23,9 +23,9 @@
   "overview_file_size": "Missing value for 'overview_file_size'",
   "download-asset": "Missing value for 'download-asset'",
   "download-metadata": "Missing value for 'download-metadata'",
+  "station.load.error": "Missing value for 'station.load.error'",
   "parameter.load.error": "Erreur lors du chargement des paramètres",
   "parameter-station-mapping.load.error": "Missing value for 'parameter-station-mapping.load.error'",
-  "station.name": "Station",
-  "station.load.error": "Missing value for 'station.load.error'",
-  "station.search.placeholder": "Chercher une station"
+  "map.load.error": "Missing value for 'map.load.error'",
+  "map.not-initialized.error": "Missing value for 'map.not-initialized.error'"
 }

--- a/public/i18n/fr.json
+++ b/public/i18n/fr.json
@@ -23,7 +23,9 @@
   "overview_file_size": "Missing value for 'overview_file_size'",
   "download-asset": "Missing value for 'download-asset'",
   "download-metadata": "Missing value for 'download-metadata'",
-  "station.load.error": "Missing value for 'station.load.error'",
   "parameter.load.error": "Erreur lors du chargement des paramètres",
-  "parameter-station-mapping.load.error": "Missing value for 'parameter-station-mapping.load.error'"
+  "parameter-station-mapping.load.error": "Missing value for 'parameter-station-mapping.load.error'",
+  "station.name": "Station",
+  "station.load.error": "Missing value for 'station.load.error'",
+  "station.search.placeholder": "Chercher une station"
 }

--- a/public/i18n/it.json
+++ b/public/i18n/it.json
@@ -23,7 +23,9 @@
   "overview_file_size": "Missing value for 'overview_file_size'",
   "download-asset": "Missing value for 'download-asset'",
   "download-metadata": "Missing value for 'download-metadata'",
-  "station.load.error": "Missing value for 'station.load.error'",
   "parameter.load.error": "Errore durante il caricamento dei parametri",
-  "parameter-station-mapping.load.error": "Missing value for 'parameter-station-mapping.load.error'"
+  "parameter-station-mapping.load.error": "Missing value for 'parameter-station-mapping.load.error'",
+  "station.name": "Stazione",
+  "station.load.error": "Missing value for 'station.load.error'",
+  "station.search.placeholder": "Stazione di ricerca"
 }

--- a/public/i18n/it.json
+++ b/public/i18n/it.json
@@ -10,11 +10,11 @@
   "form.stepper.time-range.label": "Missing value for 'form.stepper.time-range.label'",
   "form.stepper.overview.label": "Missing value for 'form.stepper.overview.label'",
   "form.stepper.download.label": "Missing value for 'form.stepper.download.label'",
-  "map.load.error": "Missing value for 'map.load.error'",
-  "map.not-initialized.error": "Missing value for 'map.not-initialized.error'",
   "now-time-interval": "Missing value for 'now-time-interval'",
   "recent-time-interval": "Missing value for 'recent-time-interval'",
   "historical-time-range-explanation": "Missing value for 'historical-time-range-explanation'",
+  "station.search.placeholder": "Stazione di ricerca",
+  "station.name": "Stazione",
   "overview_station_name": "Missing value for 'overview_station_name'",
   "overview_parameter_groups": "Missing value for 'overview_parameter_groups'",
   "overview_interval": "Missing value for 'overview_interval'",
@@ -23,9 +23,9 @@
   "overview_file_size": "Missing value for 'overview_file_size'",
   "download-asset": "Missing value for 'download-asset'",
   "download-metadata": "Missing value for 'download-metadata'",
+  "station.load.error": "Missing value for 'station.load.error'",
   "parameter.load.error": "Errore durante il caricamento dei parametri",
   "parameter-station-mapping.load.error": "Missing value for 'parameter-station-mapping.load.error'",
-  "station.name": "Stazione",
-  "station.load.error": "Missing value for 'station.load.error'",
-  "station.search.placeholder": "Stazione di ricerca"
+  "map.load.error": "Missing value for 'map.load.error'",
+  "map.not-initialized.error": "Missing value for 'map.not-initialized.error'"
 }

--- a/src/app/data-selection-form/components/station-selection/station-selection.component.html
+++ b/src/app/data-selection-form/components/station-selection/station-selection.component.html
@@ -1,0 +1,19 @@
+<div class="station-selection" *transloco="let t">
+  @if (filteredStations$) {
+    <mat-form-field class="station-selection__field">
+      <input
+        type="text"
+        [placeholder]="t('station.search.placeholder')"
+        [attr.aria-label]="t('station.name')"
+        matInput
+        [formControl]="formControl"
+        [matAutocomplete]="auto"
+      />
+      <mat-autocomplete #auto="matAutocomplete" [hideSingleSelectionIndicator]="true" [displayWith]="displayStationName">
+        @for (station of filteredStations$ | async; track station.id) {
+          <mat-option [value]="station">{{ station.name }}</mat-option>
+        }
+      </mat-autocomplete>
+    </mat-form-field>
+  }
+</div>

--- a/src/app/data-selection-form/components/station-selection/station-selection.component.scss
+++ b/src/app/data-selection-form/components/station-selection/station-selection.component.scss
@@ -1,0 +1,9 @@
+.station-selection {
+  min-width: 150px;
+  max-width: 500px;
+  width: 100%;
+
+  .station-selection__field {
+    width: 100%;
+  }
+}

--- a/src/app/data-selection-form/components/station-selection/station-selection.component.ts
+++ b/src/app/data-selection-form/components/station-selection/station-selection.component.ts
@@ -1,0 +1,70 @@
+import {AsyncPipe} from '@angular/common';
+import {Component, inject, OnDestroy, OnInit} from '@angular/core';
+import {FormControl, ReactiveFormsModule} from '@angular/forms';
+import {MatAutocomplete, MatAutocompleteTrigger, MatOption} from '@angular/material/autocomplete';
+import {MatFormField} from '@angular/material/form-field';
+import {MatInput} from '@angular/material/input';
+import {TranslocoDirective} from '@jsverse/transloco';
+import {concatLatestFrom} from '@ngrx/operators';
+import {Store} from '@ngrx/store';
+import {combineLatestWith, map, Observable, startWith, Subscription, tap} from 'rxjs';
+import {Station} from '../../../shared/models/station';
+import {formActions} from '../../../state/form/actions/form.actions';
+import {formFeature} from '../../../state/form/reducers/form.reducer';
+import {selectStationsFilteredBySelectedParameterGroups} from '../../../state/stations/selectors/station.selector';
+
+@Component({
+  selector: 'app-station-selection',
+  standalone: true,
+  imports: [MatFormField, ReactiveFormsModule, MatAutocompleteTrigger, MatAutocomplete, MatOption, AsyncPipe, MatInput, TranslocoDirective],
+  templateUrl: './station-selection.component.html',
+  styleUrl: './station-selection.component.scss',
+})
+export class StationSelectionComponent implements OnInit, OnDestroy {
+  private readonly store = inject(Store);
+
+  protected formControl = new FormControl<string | Station>('');
+  protected filteredStations$?: Observable<Station[]>;
+  private currentStationName?: Subscription;
+
+  public ngOnInit(): void {
+    this.filteredStations$ = this.formControl.valueChanges.pipe(
+      startWith(''),
+      tap((value) => this.dispatchValueChange(value)),
+      map((value): string => this.convertValueToString(value)),
+      combineLatestWith(this.store.select(selectStationsFilteredBySelectedParameterGroups)),
+      map(([value, stations]) => this.filterStations(value, stations)),
+    );
+    this.currentStationName = this.store
+      .select(formFeature.selectSelectedStationId)
+      .pipe(
+        concatLatestFrom(() => this.store.select(selectStationsFilteredBySelectedParameterGroups)),
+        map(([stationId, stations]) => stations.find((station) => station.id === stationId) ?? null),
+        tap((station) => this.formControl.patchValue(station)),
+      )
+      // eslint-disable-next-line rxjs-angular-x/prefer-composition -- the current value must be set by patching the form control; this is not possible within the template
+      .subscribe();
+  }
+
+  public ngOnDestroy(): void {
+    this.currentStationName?.unsubscribe();
+  }
+
+  protected displayStationName(station: Station | null): string {
+    return station?.name ? station.name : '';
+  }
+
+  private filterStations(value: string, stations: Station[]): Station[] {
+    const lowerCaseValue = value.toLowerCase();
+    return stations.filter((station) => station.name.toLowerCase().includes(lowerCaseValue));
+  }
+
+  private dispatchValueChange(value: string | Station | null): void {
+    const stationIdOrNull = value === null || typeof value === 'string' ? null : value.id;
+    this.store.dispatch(formActions.setSelectedStationId({stationId: stationIdOrNull}));
+  }
+
+  private convertValueToString(value: string | Station | null): string {
+    return typeof value === 'string' ? value : this.displayStationName(value);
+  }
+}

--- a/src/app/data-selection-form/components/station-selection/station-selection.component.ts
+++ b/src/app/data-selection-form/components/station-selection/station-selection.component.ts
@@ -28,12 +28,14 @@ export class StationSelectionComponent implements OnInit, OnDestroy {
   private currentStationName?: Subscription;
 
   public ngOnInit(): void {
-    this.filteredStations$ = this.formControl.valueChanges.pipe(
+    const valueChanges$ = this.formControl.valueChanges.pipe(
       startWith(''),
       tap((value) => this.dispatchValueChange(value)),
       map((value): string => this.convertValueToString(value)),
-      combineLatestWith(this.store.select(selectStationsFilteredBySelectedParameterGroups)),
-      map(([value, stations]) => this.filterStations(value, stations)),
+    );
+    this.filteredStations$ = this.store.select(selectStationsFilteredBySelectedParameterGroups).pipe(
+      combineLatestWith(valueChanges$),
+      map(([stations, value]) => this.filterStations(value, stations)),
     );
     this.currentStationName = this.store
       .select(formFeature.selectSelectedStationId)

--- a/src/app/data-selection-form/data-selection-form.component.html
+++ b/src/app/data-selection-form/data-selection-form.component.html
@@ -23,6 +23,7 @@
     <mat-step [completed]="(selectSelectedStationId$ | async) !== null">
       <ng-template matStepLabel>{{ t('form.stepper.station.label') }}</ng-template>
       <app-parameter-list></app-parameter-list>
+      <app-station-selection></app-station-selection>
       <app-map-container class="map-container"></app-map-container>
       <div>
         <button mat-button matStepperNext type="button" [disabled]="(selectSelectedStationId$ | async) === null">

--- a/src/app/data-selection-form/data-selection-form.component.ts
+++ b/src/app/data-selection-form/data-selection-form.component.ts
@@ -14,6 +14,7 @@ import {DownloadAssetComponent} from './components/download-asset/download-asset
 import {IntervalSelectionComponent} from './components/interval-selection/interval-selection.component';
 import {ParameterListComponent} from './components/parameter-list/parameter-list.component';
 import {SelectionOverviewComponent} from './components/selection-overview/selection-overview.component';
+import {StationSelectionComponent} from './components/station-selection/station-selection.component';
 import {TimeRangeSelectionComponent} from './components/time-range-selection/time-range-selection.component';
 import type {Language} from '../shared/models/language';
 
@@ -33,6 +34,7 @@ import type {Language} from '../shared/models/language';
     MatStepperModule,
     AsyncPipe,
     MapContainerComponent,
+    StationSelectionComponent,
   ],
   templateUrl: './data-selection-form.component.html',
   styleUrl: './data-selection-form.component.scss',

--- a/src/app/state/parameter-station-mapping/selectors/parameter-group-station-mapping.selector.ts
+++ b/src/app/state/parameter-station-mapping/selectors/parameter-group-station-mapping.selector.ts
@@ -16,17 +16,21 @@ export const selectCurrentParameterStationMappingState = createSelector(
 export const selectParameterGroupStationMappings = createSelector(
   selectCurrentParameterStationMappingState,
   selectCurrentParameterState,
-  (parameterStationMappingState, parameterState): ParameterGroupStationMapping[] =>
-    parameterStationMappingState.parameterStationMappings.reduce((uniqueGroupMappings: ParameterGroupStationMapping[], mapping) => {
-      const parameterGroup = parameterState.parameters.find((parameter) => parameter.id === mapping.parameterId)?.group;
-      if (parameterGroup) {
-        const parameterGroupId = ParameterService.extractGroupIdFromGroupName(parameterGroup);
-        const mappingExists = uniqueGroupMappings.some(
-          (uniqueGroupMapping) =>
-            uniqueGroupMapping.parameterGroupId === parameterGroupId && uniqueGroupMapping.stationId === mapping.stationId,
-        );
-        return mappingExists ? uniqueGroupMappings : [...uniqueGroupMappings, {parameterGroupId, stationId: mapping.stationId}];
+  ({parameterStationMappings}, {parameters}): ParameterGroupStationMapping[] => {
+    const groupToStationMap = new Map<string, ParameterGroupStationMapping>();
+    const parameterIdToGroupIdMap = new Map(
+      parameters.map((parameter) => [parameter.id, ParameterService.extractGroupIdFromGroupName(parameter.group)]),
+    );
+    parameterStationMappings.forEach((mapping) => {
+      const parameterGroupId = parameterIdToGroupIdMap.get(mapping.parameterId);
+      if (parameterGroupId) {
+        const groupToStationMapId = parameterGroupId + mapping.stationId;
+        const existGroupToStationMap = groupToStationMap.has(groupToStationMapId);
+        if (!existGroupToStationMap) {
+          groupToStationMap.set(groupToStationMapId, {parameterGroupId, stationId: mapping.stationId});
+        }
       }
-      return uniqueGroupMappings;
-    }, []),
+    });
+    return Array.from(groupToStationMap.values());
+  },
 );

--- a/src/app/state/parameter-station-mapping/selectors/parameter-group-station-mapping.selector.ts
+++ b/src/app/state/parameter-station-mapping/selectors/parameter-group-station-mapping.selector.ts
@@ -24,7 +24,7 @@ export const selectParameterGroupStationMappings = createSelector(
     parameterStationMappings.forEach((mapping) => {
       const parameterGroupId = parameterIdToGroupIdMap.get(mapping.parameterId);
       if (parameterGroupId) {
-        const groupToStationMapId = parameterGroupId + mapping.stationId;
+        const groupToStationMapId = `${parameterGroupId}-${mapping.stationId}`;
         const existGroupToStationMap = groupToStationMap.has(groupToStationMapId);
         if (!existGroupToStationMap) {
           groupToStationMap.set(groupToStationMapId, {parameterGroupId, stationId: mapping.stationId});

--- a/src/app/state/stations/selectors/station.selector.spec.ts
+++ b/src/app/state/stations/selectors/station.selector.spec.ts
@@ -1,9 +1,9 @@
 import {ParameterGroupStationMapping} from '../../../shared/models/parameter-group-station-mapping';
 import {Station} from '../../../shared/models/station';
-import {selectStationIdsFilteredBySelectedParameterGroups} from './station.selector';
+import {selectStationIdsFilteredBySelectedParameterGroups, selectStationsFilteredBySelectedParameterGroups} from './station.selector';
 
 describe('Station Selectors', () => {
-  describe('selectStationsFilteredByParameterGroups', () => {
+  describe('selectStationsFilteredBySelectedParameterGroups', () => {
     const stationOne: Station = {id: 'stationId1', name: 'stationName1', coordinates: {latitude: 0, longitude: 0}};
     const stationTwo: Station = {id: 'stationId2', name: 'stationName2', coordinates: {latitude: 0, longitude: 0}};
     const stationThree: Station = {id: 'stationId3', name: 'stationName3', coordinates: {latitude: 0, longitude: 0}};
@@ -21,13 +21,13 @@ describe('Station Selectors', () => {
         {parameterGroupId: 'groupId3', stationId: stationOne.id},
       ];
 
-      const result = selectStationIdsFilteredBySelectedParameterGroups.projector(
+      const result = selectStationsFilteredBySelectedParameterGroups.projector(
         {stations, loadingState: 'loaded'},
         selectedParameterGroupId,
         parameterGroupStationMappings,
       );
 
-      expect(result).toEqual(jasmine.arrayWithExactContents([stationOne.id, stationTwo.id]));
+      expect(result).toEqual(jasmine.arrayWithExactContents([stationOne, stationTwo]));
     });
 
     it('should return an empty list if no stations are found', () => {
@@ -37,7 +37,7 @@ describe('Station Selectors', () => {
         {parameterGroupId: 'groupId1', stationId: 'nonExistingStationId'},
       ];
 
-      const result = selectStationIdsFilteredBySelectedParameterGroups.projector(
+      const result = selectStationsFilteredBySelectedParameterGroups.projector(
         {stations, loadingState: 'loaded'},
         selectedParameterGroupId,
         parameterGroupStationMappings,
@@ -51,7 +51,7 @@ describe('Station Selectors', () => {
       const selectedParameterGroupId = 'groupId1';
       const parameterGroupStationMappings: ParameterGroupStationMapping[] = [];
 
-      const result = selectStationIdsFilteredBySelectedParameterGroups.projector(
+      const result = selectStationsFilteredBySelectedParameterGroups.projector(
         {stations, loadingState: 'loaded'},
         selectedParameterGroupId,
         parameterGroupStationMappings,
@@ -65,13 +65,24 @@ describe('Station Selectors', () => {
       const selectedParameterGroupId = null;
       const parameterGroupStationMappings: ParameterGroupStationMapping[] = [{parameterGroupId: 'groupId1', stationId: stationOne.id}];
 
-      const result = selectStationIdsFilteredBySelectedParameterGroups.projector(
+      const result = selectStationsFilteredBySelectedParameterGroups.projector(
         {stations, loadingState: 'loaded'},
         selectedParameterGroupId,
         parameterGroupStationMappings,
       );
 
-      expect(result).toEqual(jasmine.arrayWithExactContents([stationOne.id, stationTwo.id, stationThree.id]));
+      expect(result).toEqual(jasmine.arrayWithExactContents([stationOne, stationTwo, stationThree]));
+    });
+  });
+
+  describe('selectStationsFilteredBySelectedParameterGroups', () => {
+    it('should return a filtered list of stations and return the IDs', () => {
+      const stationOne: Station = {id: 'stationId1', name: 'stationName1', coordinates: {latitude: 0, longitude: 0}};
+      const stationTwo: Station = {id: 'stationId2', name: 'stationName2', coordinates: {latitude: 0, longitude: 0}};
+
+      const result = selectStationIdsFilteredBySelectedParameterGroups.projector([stationOne, stationTwo]);
+
+      expect(result).toEqual(jasmine.arrayWithExactContents([stationOne.id, stationTwo.id]));
     });
   });
 });

--- a/src/app/state/stations/selectors/station.selector.ts
+++ b/src/app/state/stations/selectors/station.selector.ts
@@ -1,4 +1,5 @@
 import {createSelector} from '@ngrx/store';
+import {Station} from '../../../shared/models/station';
 import {formFeature} from '../../form/reducers/form.reducer';
 import {selectParameterGroupStationMappings} from '../../parameter-station-mapping/selectors/parameter-group-station-mapping.selector';
 import {stationFeature} from '../reducers/station.reducer';
@@ -10,18 +11,23 @@ export const selectCurrentStationState = createSelector(
   (stationState, measurementDataType): StationStateEntry => stationState[measurementDataType],
 );
 
-export const selectStationIdsFilteredBySelectedParameterGroups = createSelector(
+export const selectStationsFilteredBySelectedParameterGroups = createSelector(
   selectCurrentStationState,
   formFeature.selectSelectedParameterGroupId,
   selectParameterGroupStationMappings,
-  (stationState, parameterGroupId, parameterGroupStationMappings): string[] => {
+  (stationState, parameterGroupId, parameterGroupStationMappings): Station[] => {
     if (!parameterGroupId) {
-      return stationState.stations.map((station) => station.id);
+      return stationState.stations;
     }
 
     const matchingStationIds = parameterGroupStationMappings
       .filter((mapping) => mapping.parameterGroupId === parameterGroupId)
       .map((mapping) => mapping.stationId);
-    return stationState.stations.filter((station) => matchingStationIds.includes(station.id)).map((station) => station.id);
+    return stationState.stations.filter((station) => matchingStationIds.includes(station.id));
   },
+);
+
+export const selectStationIdsFilteredBySelectedParameterGroups = createSelector(
+  selectStationsFilteredBySelectedParameterGroups,
+  (stations): string[] => stations.map((station) => station.id),
 );

--- a/src/app/state/stations/selectors/station.selector.ts
+++ b/src/app/state/stations/selectors/station.selector.ts
@@ -15,15 +15,16 @@ export const selectStationsFilteredBySelectedParameterGroups = createSelector(
   selectCurrentStationState,
   formFeature.selectSelectedParameterGroupId,
   selectParameterGroupStationMappings,
-  (stationState, parameterGroupId, parameterGroupStationMappings): Station[] => {
+  ({stations}, parameterGroupId, parameterGroupStationMappings): Station[] => {
     if (!parameterGroupId) {
-      return stationState.stations;
+      return stations;
     }
 
-    const matchingStationIds = parameterGroupStationMappings
+    const matchingStationIdsList = parameterGroupStationMappings
       .filter((mapping) => mapping.parameterGroupId === parameterGroupId)
       .map((mapping) => mapping.stationId);
-    return stationState.stations.filter((station) => matchingStationIds.includes(station.id));
+    const matchingStationIds = new Set(matchingStationIdsList);
+    return stations.filter((station) => matchingStationIds.has(station.id));
   },
 );
 


### PR DESCRIPTION
Station names can be searched using Material's autocomplete component.
There are two pipes necessary:
* one listening to the form and station changes and pushing the first one to the store
* one listening to the store and writing values back to the form (e.g. when a station gets selected in the map)

There is no endless loop happening due to the fact that the form only emits **changing** values.

After finishing the above I've noticed that the performance noticeable dropped when changing the measurement data type.
The two selectors for stations and parameter group to station mapping had to be optimized. There was a noticeable lag when changing from normal to homogeneous data. Seems like `reduce` isn't really optimized.