### PR TITLE
Add ID to station display name #56

### DIFF
--- a/src/app/data-selection-form/components/station-selection/station-selection.component.html
+++ b/src/app/data-selection-form/components/station-selection/station-selection.component.html
@@ -11,7 +11,7 @@
       />
       <mat-autocomplete #auto="matAutocomplete" [hideSingleSelectionIndicator]="true" [displayWith]="displayStationName">
         @for (station of filteredStations$ | async; track station.id) {
-          <mat-option [value]="station">{{ station.name }}</mat-option>
+          <mat-option [value]="station">{{ station.displayName }}</mat-option>
         }
       </mat-autocomplete>
     </mat-form-field>

--- a/src/app/data-selection-form/components/station-selection/station-selection.component.ts
+++ b/src/app/data-selection-form/components/station-selection/station-selection.component.ts
@@ -54,7 +54,7 @@ export class StationSelectionComponent implements OnInit, OnDestroy {
   }
 
   protected displayStationName(station: Station | null): string {
-    return station?.name ? station.name : '';
+    return station?.displayName ? station.displayName : '';
   }
 
   private filterStations(value: string, stations: Station[]): Station[] {

--- a/src/app/map/services/map.service.spec.ts
+++ b/src/app/map/services/map.service.spec.ts
@@ -115,6 +115,7 @@ describe('MapService', () => {
         {
           id: 'station-id',
           name: 'station-name',
+          displayName: 'station-display-name',
           coordinates: {longitude: 0, latitude: 0},
         },
       ];

--- a/src/app/map/services/map.service.ts
+++ b/src/app/map/services/map.service.ts
@@ -108,8 +108,8 @@ export class MapService {
           },
           properties: {
             id: station.id,
-            name: station.name,
-          } satisfies Pick<Station, 'id' | 'name'>,
+            displayName: station.displayName,
+          } satisfies Pick<Station, 'id' | 'displayName'>,
         })),
       },
       // this is a workaround to get IDs of type `string` working (otherwise only `number` is accepted)
@@ -132,7 +132,7 @@ export class MapService {
       type: 'symbol',
       source: this.stationSourceId,
       layout: {
-        'text-field': ['get', 'name'],
+        'text-field': ['get', 'displayName'],
         'text-font': ['Frutiger Neue Regular'],
         'text-size': 12,
         'text-offset': [0, 1.5],

--- a/src/app/shared/models/station.ts
+++ b/src/app/shared/models/station.ts
@@ -3,5 +3,6 @@ import {Coordinates} from './coordinates';
 export interface Station {
   id: string;
   name: string;
+  displayName: string;
   coordinates: Coordinates;
 }

--- a/src/app/stac/service/station.service.spec.ts
+++ b/src/app/stac/service/station.service.spec.ts
@@ -35,6 +35,7 @@ const testCsvStation: CsvStation = {
 const testStation: Station = {
   id: 'TEST',
   name: 'Test station',
+  displayName: 'Test station (TEST)',
   coordinates: {
     longitude: 0,
     latitude: 0,
@@ -95,9 +96,9 @@ describe('StationService', () => {
 
     expect(parameters).toEqual(
       jasmine.arrayWithExactContents([
-        {...testStation, id: aStation.stationAbbr},
-        {...testStation, id: bStation.stationAbbr},
-        {...testStation, id: cStation.stationAbbr},
+        {...testStation, id: aStation.stationAbbr, displayName: `${testStation.name} (${aStation.stationAbbr})`},
+        {...testStation, id: bStation.stationAbbr, displayName: `${testStation.name} (${bStation.stationAbbr})`},
+        {...testStation, id: cStation.stationAbbr, displayName: `${testStation.name} (${cStation.stationAbbr})`},
       ]),
     );
   });

--- a/src/app/stac/service/station.service.ts
+++ b/src/app/stac/service/station.service.ts
@@ -27,6 +27,7 @@ export class StationService {
     return {
       id: csvStation.stationAbbr,
       name: csvStation.stationName,
+      displayName: `${csvStation.stationName} (${csvStation.stationAbbr})`,
       coordinates: {
         longitude: Number(csvStation.stationCoordinatesWgs84Lon),
         latitude: Number(csvStation.stationCoordinatesWgs84Lat),

--- a/src/app/state/map/effects/map.effects.spec.ts
+++ b/src/app/state/map/effects/map.effects.spec.ts
@@ -93,7 +93,7 @@ describe('MapEffects', () => {
 
   it('should add stations to the map when mapActions.setMapAsLoaded is dispatched', (done) => {
     spyOn(mapService, 'addStationsToMap');
-    const stations: Station[] = [{id: '1', name: 'Station 1', coordinates: {longitude: 0, latitude: 0}}];
+    const stations: Station[] = [{id: '1', name: 'Station 1', displayName: 'DisplayName 1', coordinates: {longitude: 0, latitude: 0}}];
     store.overrideSelector(mapFeature.selectLoadingState, 'loaded');
     store.overrideSelector(selectCurrentStationState, {stations, loadingState: 'loaded'});
     actions$ = of(mapActions.setMapAsLoaded());
@@ -105,7 +105,7 @@ describe('MapEffects', () => {
 
   it('should not add stations to the map when mapActions.setMapAsLoaded is dispatched while the map is not loaded yet', (done) => {
     spyOn(mapService, 'addStationsToMap');
-    const stations: Station[] = [{id: '1', name: 'Station 1', coordinates: {longitude: 0, latitude: 0}}];
+    const stations: Station[] = [{id: '1', name: 'Station 1', displayName: 'DisplayName 1', coordinates: {longitude: 0, latitude: 0}}];
     store.overrideSelector(mapFeature.selectLoadingState, 'loading');
     store.overrideSelector(selectCurrentStationState, {stations, loadingState: 'loaded'});
     actions$ = of(mapActions.setMapAsLoaded());
@@ -119,7 +119,7 @@ describe('MapEffects', () => {
 
   it('should not add stations to the map when mapActions.setMapAsLoaded is dispatched while the stations are not loaded yet', (done) => {
     spyOn(mapService, 'addStationsToMap');
-    const stations: Station[] = [{id: '1', name: 'Station 1', coordinates: {longitude: 0, latitude: 0}}];
+    const stations: Station[] = [{id: '1', name: 'Station 1', displayName: 'DisplayName 1', coordinates: {longitude: 0, latitude: 0}}];
     store.overrideSelector(mapFeature.selectLoadingState, 'loaded');
     store.overrideSelector(selectCurrentStationState, {stations, loadingState: 'loading'});
     actions$ = of(mapActions.setMapAsLoaded());

--- a/src/app/state/stations/reducers/station.reducer.spec.ts
+++ b/src/app/state/stations/reducers/station.reducer.spec.ts
@@ -38,6 +38,7 @@ describe('Station Reducer', () => {
       {
         id: 'test-station-id',
         name: 'Test station name',
+        displayName: 'Test station display name',
         coordinates: {longitude: 0, latitude: 0},
       },
     ];

--- a/src/app/state/stations/selectors/station.selector.spec.ts
+++ b/src/app/state/stations/selectors/station.selector.spec.ts
@@ -4,9 +4,24 @@ import {selectStationIdsFilteredBySelectedParameterGroups, selectStationsFiltere
 
 describe('Station Selectors', () => {
   describe('selectStationsFilteredBySelectedParameterGroups', () => {
-    const stationOne: Station = {id: 'stationId1', name: 'stationName1', coordinates: {latitude: 0, longitude: 0}};
-    const stationTwo: Station = {id: 'stationId2', name: 'stationName2', coordinates: {latitude: 0, longitude: 0}};
-    const stationThree: Station = {id: 'stationId3', name: 'stationName3', coordinates: {latitude: 0, longitude: 0}};
+    const stationOne: Station = {
+      id: 'stationId1',
+      name: 'stationName1',
+      displayName: 'stationDisplayName1',
+      coordinates: {latitude: 0, longitude: 0},
+    };
+    const stationTwo: Station = {
+      id: 'stationId2',
+      name: 'stationName2',
+      displayName: 'stationDisplayName2',
+      coordinates: {latitude: 0, longitude: 0},
+    };
+    const stationThree: Station = {
+      id: 'stationId3',
+      name: 'stationName3',
+      displayName: 'stationDisplayName3',
+      coordinates: {latitude: 0, longitude: 0},
+    };
 
     it('should return a filtered list of stations', () => {
       const stations: Station[] = [stationOne, stationTwo, stationThree];
@@ -77,8 +92,18 @@ describe('Station Selectors', () => {
 
   describe('selectStationsFilteredBySelectedParameterGroups', () => {
     it('should return a filtered list of stations and return the IDs', () => {
-      const stationOne: Station = {id: 'stationId1', name: 'stationName1', coordinates: {latitude: 0, longitude: 0}};
-      const stationTwo: Station = {id: 'stationId2', name: 'stationName2', coordinates: {latitude: 0, longitude: 0}};
+      const stationOne: Station = {
+        id: 'stationId1',
+        name: 'stationName1',
+        displayName: 'stationDisplayName1',
+        coordinates: {latitude: 0, longitude: 0},
+      };
+      const stationTwo: Station = {
+        id: 'stationId2',
+        name: 'stationName2',
+        displayName: 'stationDisplayName2',
+        coordinates: {latitude: 0, longitude: 0},
+      };
 
       const result = selectStationIdsFilteredBySelectedParameterGroups.projector([stationOne, stationTwo]);
 


### PR DESCRIPTION
`Station` contains now a property `displayName` which is a combination between its name and ID. This is necessary because some stations have the same name but must be searchable. Therefore the name alone is not sufficient.