### PR TITLE
All form parameters in URL #53

### DIFF
--- a/src/app/data-selection-form/components/station-selection/station-selection.component.ts
+++ b/src/app/data-selection-form/components/station-selection/station-selection.component.ts
@@ -30,8 +30,9 @@ export class StationSelectionComponent implements OnInit, OnDestroy {
   public ngOnInit(): void {
     const valueChanges$ = this.formControl.valueChanges.pipe(
       startWith(''),
-      tap((value) => this.dispatchValueChange(value)),
-      map((value): string => this.convertValueToString(value)),
+      concatLatestFrom(() => this.store.select(formFeature.selectSelectedStationId)),
+      tap(([value, selectedStationId]) => this.dispatchValueChange(value, selectedStationId)),
+      map(([value]): string => this.convertValueToString(value)),
     );
     this.filteredStations$ = this.store.select(selectUniqueStationsFilteredBySelectedParameterGroups).pipe(
       combineLatestWith(valueChanges$),
@@ -62,9 +63,11 @@ export class StationSelectionComponent implements OnInit, OnDestroy {
     return stations.filter((station) => station.displayName.toLowerCase().includes(lowerCaseValue));
   }
 
-  private dispatchValueChange(value: string | Station | null): void {
+  private dispatchValueChange(value: string | Station | null, selectedStationId: string | null): void {
     const stationIdOrNull = value === null || typeof value === 'string' ? null : value.id;
-    this.store.dispatch(formActions.setSelectedStationId({stationId: stationIdOrNull}));
+    if (stationIdOrNull !== selectedStationId) {
+      this.store.dispatch(formActions.setSelectedStationId({stationId: stationIdOrNull}));
+    }
   }
 
   private convertValueToString(value: string | Station | null): string {

--- a/src/app/shared/models/app-url-parameter.ts
+++ b/src/app/shared/models/app-url-parameter.ts
@@ -1,9 +1,14 @@
+import {DataInterval} from './interval';
 import {Language} from './language';
 import {MeasurementDataType} from './measurement-data-type';
+import {TimeRange} from './time-range';
 
 export interface AppUrlParameter {
   language: Language;
   measurementDataType: MeasurementDataType;
   parameterGroupId: string | null;
   stationId: string | null;
+  collection: string | null;
+  dataInterval: DataInterval | null;
+  timeRange: TimeRange | null;
 }

--- a/src/app/shared/models/time-range.ts
+++ b/src/app/shared/models/time-range.ts
@@ -1,1 +1,2 @@
-export type TimeRange = 'current-day' | 'current-year' | 'all-time';
+export const timeRanges = ['now', 'recent', 'historical'] as const;
+export type TimeRange = (typeof timeRanges)[number];

--- a/src/app/shared/services/url-parameter.service.ts
+++ b/src/app/shared/services/url-parameter.service.ts
@@ -1,32 +1,34 @@
 import {DOCUMENT} from '@angular/common';
 import {inject, Injectable} from '@angular/core';
-import {Store} from '@ngrx/store';
-import {map, Observable, take} from 'rxjs';
-import {selectCurrentAppUrlParameter} from '../../state/app/selectors/app.selector';
 import {collectionConfig} from '../configs/collections.config';
 import {languageConfig} from '../configs/language.config';
 import {AppUrlParameter} from '../models/app-url-parameter';
 import {HostMessage} from '../models/host-message';
-import {Language} from '../models/language';
+import {isDataInterval} from '../type-guards/data-interval-guard';
 import {isLanguage} from '../type-guards/language-guard';
 import {isMeasurementDataType} from '../type-guards/measurement-data-type-guard';
+import {isTimeRange} from '../type-guards/time-range-guard';
 
 @Injectable({
   providedIn: 'root',
 })
 export class UrlParameterService {
   private readonly document = inject(DOCUMENT);
-  private readonly store = inject(Store);
 
   private readonly languageKey = 'lang' as const;
   private readonly measurementDataTypeKey = 'mdt' as const;
   private readonly parameterGroupIdKey = 'pgid' as const;
   private readonly stationIdKey = 'sid' as const;
+  private readonly collectionKey = 'col' as const;
+  private readonly dataIntervalKey = 'di' as const;
+  private readonly timeRangeKey = 'tr' as const;
 
   public transformUrlFragmentToAppUrlParameter(fragment: string | undefined): AppUrlParameter {
     const urlParams = new URLSearchParams(fragment);
     const languageString = urlParams.get(this.languageKey);
     const measurementDataTypeString = urlParams.get(this.measurementDataTypeKey);
+    const dataIntervalString = urlParams.get(this.dataIntervalKey);
+    const timeRangeString = urlParams.get(this.timeRangeKey);
     return {
       language: languageString && isLanguage(languageString) ? languageString : languageConfig.defaultLanguage,
       measurementDataType:
@@ -35,56 +37,33 @@ export class UrlParameterService {
           : collectionConfig.defaultMeasurementDataType,
       parameterGroupId: urlParams.get(this.parameterGroupIdKey),
       stationId: urlParams.get(this.stationIdKey),
+      collection: urlParams.get(this.collectionKey),
+      dataInterval: dataIntervalString && isDataInterval(dataIntervalString) ? dataIntervalString : null,
+      timeRange: timeRangeString && isTimeRange(timeRangeString) ? timeRangeString : null,
     };
   }
 
-  public setLanguage(language: Language): Observable<void> {
-    return this.setUrlParameter(this.languageKey, language);
+  public setUrlFragment(appUrlParameter: AppUrlParameter): void {
+    const urlFragment = this.transformAppUrlParameterToUrlFragment(appUrlParameter);
+    const message: HostMessage = {src: urlFragment};
+    const window = this.document.defaultView;
+    if (!window) {
+      // this should never happen™ at this point
+      throw new Error('Window is not available');
+    }
+
+    if (window !== window.parent) {
+      // this sends a message to the parent window outside the iframe context (to set the fragment to the current URL)
+      // Remark: the targetOrigin is set to '*' so that it works across multiple domain boundaries
+      //         there shouldn't be a security issue with that as all data is already public and there is no authentication involved
+      window.parent.postMessage(message, '*');
+    } else {
+      // this sets the fragment directly to the current URL
+      window.location.hash = urlFragment;
+    }
   }
 
-  public setMeasurementDataType(measurementDataType: string): Observable<void> {
-    return this.setUrlParameter(this.measurementDataTypeKey, measurementDataType);
-  }
-
-  public setParameterGroupId(parameterGroupId: string | null): Observable<void> {
-    return this.setUrlParameter(this.parameterGroupIdKey, parameterGroupId);
-  }
-
-  public setStationId(stationId: string | null): Observable<void> {
-    return this.setUrlParameter(this.stationIdKey, stationId);
-  }
-
-  private setUrlParameter(key: string, value: string | null): Observable<void> {
-    return this.store.select(selectCurrentAppUrlParameter).pipe(
-      take(1),
-      map((appUrlParameter) => {
-        const currentUrlParams = this.transformAppUrlParameterToUrlFragment(appUrlParameter);
-        if (value === null) {
-          currentUrlParams.delete(key);
-        } else {
-          currentUrlParams.set(key, value);
-        }
-        const message: HostMessage = {src: currentUrlParams.toString()};
-        const window = this.document.defaultView;
-        if (!window) {
-          // this should never happen™ at this point
-          throw new Error('Window is not available');
-        }
-
-        if (window !== window.parent) {
-          // this sends a message to the parent window outside the iframe context (to set the fragment to the current URL)
-          // Remark: the targetOrigin is set to '*' so that it works across multiple domain boundaries
-          //         there shouldn't be a security issue with that as all data is already public and there is no authentication involved
-          window.parent.postMessage(message, '*');
-        } else {
-          // this sets the fragment directly to the current URL
-          window.location.hash = currentUrlParams.toString();
-        }
-      }),
-    );
-  }
-
-  private transformAppUrlParameterToUrlFragment(appUrlParameter: AppUrlParameter): URLSearchParams {
+  private transformAppUrlParameterToUrlFragment(appUrlParameter: AppUrlParameter): string {
     const urlParams = new URLSearchParams();
     urlParams.set(this.languageKey, appUrlParameter.language);
     urlParams.set(this.measurementDataTypeKey, appUrlParameter.measurementDataType);
@@ -94,6 +73,15 @@ export class UrlParameterService {
     if (appUrlParameter.stationId) {
       urlParams.set(this.stationIdKey, appUrlParameter.stationId);
     }
-    return urlParams;
+    if (appUrlParameter.collection) {
+      urlParams.set(this.collectionKey, appUrlParameter.collection);
+    }
+    if (appUrlParameter.dataInterval) {
+      urlParams.set(this.dataIntervalKey, appUrlParameter.dataInterval);
+    }
+    if (appUrlParameter.timeRange) {
+      urlParams.set(this.timeRangeKey, appUrlParameter.timeRange);
+    }
+    return urlParams.toString();
   }
 }

--- a/src/app/shared/type-guards/data-interval-guard.spec.ts
+++ b/src/app/shared/type-guards/data-interval-guard.spec.ts
@@ -1,0 +1,26 @@
+import {dataIntervals} from '../models/interval';
+import {isDataInterval} from './data-interval-guard';
+
+describe('isDataInterval', () => {
+  dataIntervals.forEach((dataInterval) => {
+    it(`returns true for '${dataInterval}'`, () => {
+      expect(isDataInterval(`${dataInterval}`)).toBe(true);
+    });
+  });
+
+  it('returns false for a misspelled dataInterval string', () => {
+    expect(isDataInterval('dayly')).toBe(false);
+  });
+
+  it('returns false for an uppercase dataInterval string', () => {
+    expect(isDataInterval('DAILY')).toBe(false);
+  });
+
+  it('returns false for an invalid dataInterval', () => {
+    expect(isDataInterval('whoopsy')).toBe(false);
+  });
+
+  it('returns false for an empty string', () => {
+    expect(isDataInterval('')).toBe(false);
+  });
+});

--- a/src/app/shared/type-guards/data-interval-guard.ts
+++ b/src/app/shared/type-guards/data-interval-guard.ts
@@ -1,0 +1,5 @@
+import {DataInterval, dataIntervals} from '../models/interval';
+
+export function isDataInterval(value: string): value is DataInterval {
+  return dataIntervals.includes(value as DataInterval);
+}

--- a/src/app/shared/type-guards/time-range-guard.spec.ts
+++ b/src/app/shared/type-guards/time-range-guard.spec.ts
@@ -1,0 +1,26 @@
+import {timeRanges} from '../models/time-range';
+import {isTimeRange} from './time-range-guard';
+
+describe('isTimeRange', () => {
+  timeRanges.forEach((timeRange) => {
+    it(`returns true for '${timeRange}'`, () => {
+      expect(isTimeRange(`${timeRange}`)).toBe(true);
+    });
+  });
+
+  it('returns false for a misspelled timeRange string', () => {
+    expect(isTimeRange('nov')).toBe(false);
+  });
+
+  it('returns false for an uppercase timeRange string', () => {
+    expect(isTimeRange('NOW')).toBe(false);
+  });
+
+  it('returns false for an invalid timeRange', () => {
+    expect(isTimeRange('whoopsy')).toBe(false);
+  });
+
+  it('returns false for an empty string', () => {
+    expect(isTimeRange('')).toBe(false);
+  });
+});

--- a/src/app/shared/type-guards/time-range-guard.ts
+++ b/src/app/shared/type-guards/time-range-guard.ts
@@ -1,0 +1,5 @@
+import {TimeRange, timeRanges} from '../models/time-range';
+
+export function isTimeRange(value: string): value is TimeRange {
+  return timeRanges.includes(value as TimeRange);
+}

--- a/src/app/state/app/effects/app.effects.spec.ts
+++ b/src/app/state/app/effects/app.effects.spec.ts
@@ -4,7 +4,7 @@ import {Action} from '@ngrx/store';
 import {Observable, of} from 'rxjs';
 import {AppUrlParameter} from '../../../shared/models/app-url-parameter';
 import {appActions} from '../actions/app.actions';
-import {initializeLanguage, setLanguage, setLanguageInUrl} from './app.effects';
+import {initializeLanguage, setLanguage} from './app.effects';
 
 describe('AppEffects', () => {
   let actions$: Observable<Action>;
@@ -30,16 +30,6 @@ describe('AppEffects', () => {
     actions$ = of(appActions.initializeApp({parameter: {language: 'fr'} as AppUrlParameter}));
     initializeLanguage(actions$).subscribe((action) => {
       expect(action).toEqual(appActions.setLanguage({language: 'fr'}));
-      done();
-    });
-  });
-
-  it('should call the urlParameterService when appActions.setLanguage is dispatched', (done: DoneFn) => {
-    const urlParameterService = jasmine.createSpyObj('UrlParameterService', ['setLanguage']);
-    urlParameterService.setLanguage.and.returnValue(of(undefined));
-    actions$ = of(appActions.setLanguage({language: 'en'}));
-    setLanguageInUrl(actions$, urlParameterService).subscribe(() => {
-      expect(urlParameterService.setLanguage).toHaveBeenCalledOnceWith('en');
       done();
     });
   });

--- a/src/app/state/app/effects/app.effects.ts
+++ b/src/app/state/app/effects/app.effects.ts
@@ -1,8 +1,7 @@
 import {inject} from '@angular/core';
 import {TranslocoService} from '@jsverse/transloco';
 import {Actions, createEffect, ofType} from '@ngrx/effects';
-import {map, switchMap, tap} from 'rxjs';
-import {UrlParameterService} from '../../../shared/services/url-parameter.service';
+import {map, tap} from 'rxjs';
 import {appActions} from '../actions/app.actions';
 
 export const setLanguage = createEffect(
@@ -23,14 +22,4 @@ export const initializeLanguage = createEffect(
     );
   },
   {functional: true},
-);
-
-export const setLanguageInUrl = createEffect(
-  (actions$ = inject(Actions), urlParameterService = inject(UrlParameterService)) => {
-    return actions$.pipe(
-      ofType(appActions.setLanguage),
-      switchMap(({language}) => urlParameterService.setLanguage(language)),
-    );
-  },
-  {functional: true, dispatch: false},
 );

--- a/src/app/state/app/effects/url-parameter.effects.spec.ts
+++ b/src/app/state/app/effects/url-parameter.effects.spec.ts
@@ -5,9 +5,11 @@ import {MockStore, provideMockStore} from '@ngrx/store/testing';
 import {Observable, of} from 'rxjs';
 import {AppUrlParameter} from '../../../shared/models/app-url-parameter';
 import {UrlParameterService} from '../../../shared/services/url-parameter.service';
+import {formActions} from '../../form/actions/form.actions';
 import {appActions} from '../actions/app.actions';
 import {appFeature} from '../reducers/app.reducer';
-import {initializeApp} from './url-parameter.effects';
+import {selectCurrentAppUrlParameter} from '../selectors/app.selector';
+import {initializeApp, setUrlParameter} from './url-parameter.effects';
 
 describe('UrlParameterEffects', () => {
   let actions$: Observable<Action>;
@@ -16,7 +18,7 @@ describe('UrlParameterEffects', () => {
 
   beforeEach(() => {
     actions$ = new Observable<Action>();
-    urlParameterService = jasmine.createSpyObj('UrlParameterService', ['transformUrlFragmentToAppUrlParameter']);
+    urlParameterService = jasmine.createSpyObj('UrlParameterService', ['transformUrlFragmentToAppUrlParameter', 'setUrlFragment']);
     TestBed.configureTestingModule({
       providers: [provideMockStore(), {provide: UrlParameterService, useValue: urlParameterService}],
     });
@@ -27,35 +29,60 @@ describe('UrlParameterEffects', () => {
     store.resetSelectors();
   });
 
-  it('dispatches initializeApp action when routerNavigatedAction is dispatched and the app is not yet initialized', (done: DoneFn) => {
-    const fragment = 'something';
-    const appInitializeParameter: AppUrlParameter = {
-      language: 'en',
-      measurementDataType: 'homogenous',
-      parameterGroupId: '123',
-      stationId: '456',
-    };
-    urlParameterService.transformUrlFragmentToAppUrlParameter.and.returnValue(appInitializeParameter);
-    store.overrideSelector(appFeature.selectIsInitialized, false);
-    const payload = {routerState: {root: {fragment}}} as RouterNavigatedPayload;
-    actions$ = of(routerNavigatedAction({payload}));
+  describe('initializeApp', () => {
+    it('dispatches initializeApp action when routerNavigatedAction is dispatched and the app is not yet initialized', (done: DoneFn) => {
+      const fragment = 'something';
+      const appInitializeParameter: AppUrlParameter = {
+        language: 'en',
+        measurementDataType: 'homogenous',
+        parameterGroupId: '123',
+        stationId: '456',
+        collection: '789',
+        dataInterval: 'yearly',
+        timeRange: 'historical',
+      };
+      urlParameterService.transformUrlFragmentToAppUrlParameter.and.returnValue(appInitializeParameter);
+      store.overrideSelector(appFeature.selectIsInitialized, false);
+      const payload = {routerState: {root: {fragment}}} as RouterNavigatedPayload;
+      actions$ = of(routerNavigatedAction({payload}));
 
-    initializeApp(actions$, store, urlParameterService).subscribe((action) => {
-      expect(action).toEqual(appActions.initializeApp({parameter: appInitializeParameter}));
-      done();
+      initializeApp(actions$, store, urlParameterService).subscribe((action) => {
+        expect(action).toEqual(appActions.initializeApp({parameter: appInitializeParameter}));
+        done();
+      });
+    });
+
+    it('does not dispatch initializeApp action if app is already initialized', (done: DoneFn) => {
+      store.overrideSelector(appFeature.selectIsInitialized, true);
+      const payload = {routerState: {root: {fragment: null}}} as RouterNavigatedPayload;
+      actions$ = of(routerNavigatedAction({payload}));
+
+      initializeApp(actions$, store, urlParameterService).subscribe({
+        complete: () => {
+          expect(urlParameterService.transformUrlFragmentToAppUrlParameter).not.toHaveBeenCalled();
+          done();
+        },
+      });
     });
   });
 
-  it('does not dispatch initializeApp action if app is already initialized', (done: DoneFn) => {
-    store.overrideSelector(appFeature.selectIsInitialized, true);
-    const payload = {routerState: {root: {fragment: null}}} as RouterNavigatedPayload;
-    actions$ = of(routerNavigatedAction({payload}));
-
-    initializeApp(actions$, store, urlParameterService).subscribe({
-      complete: () => {
-        expect(urlParameterService.transformUrlFragmentToAppUrlParameter).not.toHaveBeenCalled();
+  describe('setUrlParameter', () => {
+    it('calls urlParameterService when setSelectedMeasurementDataType is dispatched', (done: DoneFn) => {
+      const appUrlParameter: AppUrlParameter = {
+        language: 'en',
+        measurementDataType: 'homogenous',
+        parameterGroupId: null,
+        stationId: null,
+        collection: null,
+        dataInterval: null,
+        timeRange: null,
+      };
+      store.overrideSelector(selectCurrentAppUrlParameter, appUrlParameter);
+      actions$ = of(formActions.setSelectedMeasurementDataType({measurementDataType: 'homogenous'}));
+      setUrlParameter(actions$, store, urlParameterService).subscribe(() => {
+        expect(urlParameterService.setUrlFragment).toHaveBeenCalledOnceWith(appUrlParameter);
         done();
-      },
+      });
     });
   });
 });

--- a/src/app/state/app/effects/url-parameter.effects.ts
+++ b/src/app/state/app/effects/url-parameter.effects.ts
@@ -3,10 +3,12 @@ import {Actions, createEffect, ofType} from '@ngrx/effects';
 import {concatLatestFrom} from '@ngrx/operators';
 import {routerNavigatedAction} from '@ngrx/router-store';
 import {Store} from '@ngrx/store';
-import {filter, map} from 'rxjs';
+import {filter, map, tap} from 'rxjs';
 import {UrlParameterService} from '../../../shared/services/url-parameter.service';
+import {formActions} from '../../form/actions/form.actions';
 import {appActions} from '../actions/app.actions';
 import {appFeature} from '../reducers/app.reducer';
+import {selectCurrentAppUrlParameter} from '../selectors/app.selector';
 
 export const initializeApp = createEffect(
   (actions$ = inject(Actions), store = inject(Store), urlParameterService = inject(UrlParameterService)) => {
@@ -22,4 +24,23 @@ export const initializeApp = createEffect(
     );
   },
   {functional: true},
+);
+
+export const setUrlParameter = createEffect(
+  (actions$ = inject(Actions), store = inject(Store), urlParameterService = inject(UrlParameterService)) => {
+    return actions$.pipe(
+      ofType(
+        appActions.setLanguage,
+        formActions.setSelectedMeasurementDataType,
+        formActions.setSelectedParameters,
+        formActions.setSelectedStationId,
+        formActions.setSelectedCollection,
+        formActions.setSelectedDataInterval,
+        formActions.setSelectedTimeRange,
+      ),
+      concatLatestFrom(() => store.select(selectCurrentAppUrlParameter)),
+      tap(([, appUrlParameter]) => urlParameterService.setUrlFragment(appUrlParameter)),
+    );
+  },
+  {functional: true, dispatch: false},
 );

--- a/src/app/state/app/selectors/app.selector.ts
+++ b/src/app/state/app/selectors/app.selector.ts
@@ -5,13 +5,14 @@ import {appFeature} from '../reducers/app.reducer';
 
 export const selectCurrentAppUrlParameter = createSelector(
   appFeature.selectLanguage,
-  formFeature.selectSelectedMeasurementDataType,
-  formFeature.selectSelectedParameterGroupId,
-  formFeature.selectSelectedStationId,
-  (language, measurementDataType, parameterGroupId, stationId): AppUrlParameter => ({
+  formFeature.selectFormState,
+  (language, formState): AppUrlParameter => ({
     language,
-    measurementDataType,
-    parameterGroupId,
-    stationId,
+    measurementDataType: formState.selectedMeasurementDataType,
+    parameterGroupId: formState.selectedParameterGroupId,
+    stationId: formState.selectedStationId,
+    collection: formState.selectedCollection,
+    dataInterval: formState.selectedDataInterval,
+    timeRange: formState.selectedTimeRange,
   }),
 );

--- a/src/app/state/form/actions/form.actions.ts
+++ b/src/app/state/form/actions/form.actions.ts
@@ -8,7 +8,11 @@ export const formActions = createActionGroup({
   events: {
     'Set selected parameters': props<{parameterGroupId: string | null}>(),
     'Set selected station id': props<{stationId: string | null}>(),
-    'Set selected parameter group and station id': props<{parameterGroupId: string | null; stationId: string | null}>(),
+    'Set selected parameter group and station id and collection': props<{
+      parameterGroupId: string | null;
+      stationId: string | null;
+      collection: string | null;
+    }>(),
     'Set selected dataInterval': props<{dataInterval: DataInterval}>(),
     'Set selected time range': props<{timeRange: TimeRange}>(),
     'Set selected measurement data type': props<{measurementDataType: MeasurementDataType}>(),

--- a/src/app/state/form/effects/form.effects.ts
+++ b/src/app/state/form/effects/form.effects.ts
@@ -2,9 +2,8 @@ import {inject} from '@angular/core';
 import {Actions, createEffect, ofType} from '@ngrx/effects';
 import {concatLatestFrom} from '@ngrx/operators';
 import {Store} from '@ngrx/store';
-import {combineLatestWith, filter, map, switchMap, take} from 'rxjs';
+import {combineLatestWith, filter, map, take} from 'rxjs';
 import {collectionConfig} from '../../../shared/configs/collections.config';
-import {UrlParameterService} from '../../../shared/services/url-parameter.service';
 import {appActions} from '../../app/actions/app.actions';
 import {collectionActions} from '../../collection/actions/collection.action';
 import {selectCombinedLoadingState} from '../../collection/selectors/collection.selector';
@@ -46,7 +45,7 @@ export const initializeSelectedMeasurementDataType = createEffect(
   {functional: true},
 );
 
-export const initializeSelectedStationAndParameterGroupId = createEffect(
+export const initializeSelectedStationIdAndParameterGroupIdAndCollection = createEffect(
   (actions$ = inject(Actions), store = inject(Store)) => {
     return actions$.pipe(
       ofType(appActions.initializeApp),
@@ -62,39 +61,12 @@ export const initializeSelectedStationAndParameterGroupId = createEffect(
         const parameterGroupId =
           parameterGroups.map((parameterGroup) => parameterGroup.id).find((id) => id === parameter.parameterGroupId) ?? null;
         const stationId = stations.map((station) => station.id).find((id) => id === parameter.stationId) ?? null;
-        return formActions.setSelectedParameterGroupAndStationId({parameterGroupId, stationId});
+        const collection =
+          stations.filter((station) => station.id === stationId).find((station) => station.collection === parameter.collection)
+            ?.collection ?? null;
+        return formActions.setSelectedParameterGroupAndStationIdAndCollection({parameterGroupId, stationId, collection});
       }),
     );
   },
   {functional: true},
-);
-
-export const setSelectedMeasurementDataTypeInUrl = createEffect(
-  (actions$ = inject(Actions), urlParameterService = inject(UrlParameterService)) => {
-    return actions$.pipe(
-      ofType(formActions.setSelectedMeasurementDataType),
-      switchMap(({measurementDataType}) => urlParameterService.setMeasurementDataType(measurementDataType)),
-    );
-  },
-  {functional: true, dispatch: false},
-);
-
-export const setSelectedParameterGroupIdInUrl = createEffect(
-  (actions$ = inject(Actions), urlParameterService = inject(UrlParameterService)) => {
-    return actions$.pipe(
-      ofType(formActions.setSelectedParameters),
-      switchMap(({parameterGroupId}) => urlParameterService.setParameterGroupId(parameterGroupId)),
-    );
-  },
-  {functional: true, dispatch: false},
-);
-
-export const setSelectedStationIdInUrl = createEffect(
-  (actions$ = inject(Actions), urlParameterService = inject(UrlParameterService)) => {
-    return actions$.pipe(
-      ofType(formActions.setSelectedStationId),
-      switchMap(({stationId}) => urlParameterService.setStationId(stationId)),
-    );
-  },
-  {functional: true, dispatch: false},
 );

--- a/src/app/state/form/reducers/form.reducer.spec.ts
+++ b/src/app/state/form/reducers/form.reducer.spec.ts
@@ -11,7 +11,7 @@ describe('Form Reducer', () => {
       selectedParameterGroupId: 'A',
       selectedStationId: 'ALT',
       selectedDataInterval: 'daily',
-      selectedTimeRange: 'all-time',
+      selectedTimeRange: 'historical',
       selectedCollection: 'collection',
     };
   });
@@ -50,7 +50,11 @@ describe('Form Reducer', () => {
   });
 
   it('should reset selection of upcoming steps if parameter group ID and station ID are selected', () => {
-    const action = formActions.setSelectedParameterGroupAndStationId({parameterGroupId: 'paramGroupTest', stationId: 'stationTest'});
+    const action = formActions.setSelectedParameterGroupAndStationIdAndCollection({
+      parameterGroupId: 'paramGroupTest',
+      stationId: 'stationTest',
+      collection: 'collectionTest',
+    });
 
     const result = formFeature.reducer(state, action);
 
@@ -59,6 +63,7 @@ describe('Form Reducer', () => {
       selectedMeasurementDataType: 'normal',
       selectedParameterGroupId: 'paramGroupTest',
       selectedStationId: 'stationTest',
+      selectedCollection: 'collectionTest',
     });
   });
 
@@ -92,7 +97,7 @@ describe('Form Reducer', () => {
   });
 
   it('should just set time range if it is selected', () => {
-    const action = formActions.setSelectedTimeRange({timeRange: 'current-day'});
+    const action = formActions.setSelectedTimeRange({timeRange: 'now'});
 
     const result = formFeature.reducer(state, action);
 
@@ -101,7 +106,7 @@ describe('Form Reducer', () => {
       selectedParameterGroupId: 'A',
       selectedStationId: 'ALT',
       selectedDataInterval: 'daily',
-      selectedTimeRange: 'current-day',
+      selectedTimeRange: 'now',
       selectedCollection: 'collection',
     });
   });

--- a/src/app/state/form/reducers/form.reducer.ts
+++ b/src/app/state/form/reducers/form.reducer.ts
@@ -44,12 +44,12 @@ export const formFeature = createFeature({
       }),
     ),
     on(
-      formActions.setSelectedParameterGroupAndStationId,
-      (state, {parameterGroupId, stationId}): FormState => ({
+      formActions.setSelectedParameterGroupAndStationIdAndCollection,
+      (state, {parameterGroupId, stationId, collection}): FormState => ({
         ...state,
         selectedParameterGroupId: parameterGroupId,
         selectedStationId: stationId,
-        selectedCollection: null,
+        selectedCollection: collection,
         selectedDataInterval: null,
         selectedTimeRange: null,
       }),

--- a/src/app/state/map/effects/map.effects.ts
+++ b/src/app/state/map/effects/map.effects.ts
@@ -78,7 +78,11 @@ export const addStationsToMap = createEffect(
 export const filterStationsOnMap = createEffect(
   (actions$ = inject(Actions), store = inject(Store), mapService = inject(MapService)) => {
     return actions$.pipe(
-      ofType(formActions.setSelectedParameters, mapActions.completeLayersInitialization, formActions.setSelectedParameterGroupAndStationId),
+      ofType(
+        formActions.setSelectedParameters,
+        mapActions.completeLayersInitialization,
+        formActions.setSelectedParameterGroupAndStationIdAndCollection,
+      ),
       concatLatestFrom(() => store.select(mapFeature.selectMapsState)),
       filter(([, {loadingState, areLayersInitialized}]) => loadingState === 'loaded' && areLayersInitialized),
       concatLatestFrom(() => store.select(selectUniqueStationIdsFilteredBySelectedParameterGroups)),
@@ -111,7 +115,7 @@ export const highlightSelectedStationOnMap = createEffect(
         formActions.setSelectedStationId,
         formActions.setSelectedParameters,
         mapActions.setMapAsLoaded,
-        formActions.setSelectedParameterGroupAndStationId,
+        formActions.setSelectedParameterGroupAndStationIdAndCollection,
       ),
       concatLatestFrom(() => store.select(mapFeature.selectLoadingState)),
       filter(([, loadingState]) => loadingState === 'loaded'),


### PR DESCRIPTION
There are three different (but interwoven) changes:
* url-parameter.service is heavily simplified by only accepting the new app-url-parameter
* app-url-parameter contains now all form state properties
* collection is now part of the app initialization

The url-parameter.effects are now responsible to listen for the right actions and set the URL parameter accordingly. This makes it much easier to add new parameters as there is only one place to modify.

Also there was a minor issue in station-selection.component where the station ID was dispatched too many times even if nothing else changed.

The app URL state should be complete now with these changes. The only thing missing is the initialization of the data interval and time range which is done in their own PR.