### PR TITLE
Retrieve Station Assets from the STAC API #41

### DIFF
--- a/public/i18n/de.json
+++ b/public/i18n/de.json
@@ -28,5 +28,7 @@
   "parameter.load.error": "Fehler beim Laden der Parameter",
   "parameter-station-mapping.load.error": "Missing value for 'parameter-station-mapping.load.error'",
   "map.load.error": "Missing value for 'map.load.error'",
-  "map.not-initialized.error": "Missing value for 'map.not-initialized.error'"
+  "map.not-initialized.error": "Missing value for 'map.not-initialized.error'",
+  "asset.load.error": "Missing value for 'asset.load.error'",
+  "asset.parse.error": "Missing value for 'asset.parse.error'"
 }

--- a/public/i18n/de.json
+++ b/public/i18n/de.json
@@ -30,5 +30,5 @@
   "map.load.error": "Missing value for 'map.load.error'",
   "map.not-initialized.error": "Missing value for 'map.not-initialized.error'",
   "asset.load.error": "Missing value for 'asset.load.error'",
-  "asset.parse.error": "Missing value for 'asset.parse.error'"
+  "asset.parse.error": "Fehler beim lesen der Datei '{{filename}}'"
 }

--- a/public/i18n/en.json
+++ b/public/i18n/en.json
@@ -28,5 +28,7 @@
   "parameter.load.error": "Error loading parameters",
   "parameter-station-mapping.load.error": "Missing value for 'parameter-station-mapping.load.error'",
   "map.load.error": "Missing value for 'map.load.error'",
-  "map.not-initialized.error": "Missing value for 'map.not-initialized.error'"
+  "map.not-initialized.error": "Missing value for 'map.not-initialized.error'",
+  "asset.load.error": "Missing value for 'asset.load.error'",
+  "asset.parse.error": "Missing value for 'asset.parse.error'"
 }

--- a/public/i18n/en.json
+++ b/public/i18n/en.json
@@ -30,5 +30,5 @@
   "map.load.error": "Missing value for 'map.load.error'",
   "map.not-initialized.error": "Missing value for 'map.not-initialized.error'",
   "asset.load.error": "Missing value for 'asset.load.error'",
-  "asset.parse.error": "Missing value for 'asset.parse.error'"
+  "asset.parse.error": "Error while parsing file '{{filename}}'"
 }

--- a/public/i18n/fr.json
+++ b/public/i18n/fr.json
@@ -30,5 +30,5 @@
   "map.load.error": "Missing value for 'map.load.error'",
   "map.not-initialized.error": "Missing value for 'map.not-initialized.error'",
   "asset.load.error": "Missing value for 'asset.load.error'",
-  "asset.parse.error": "Missing value for 'asset.parse.error'"
+  "asset.parse.error": "Erreur lors de l'analyse du fichier '{{filename}}''"
 }

--- a/public/i18n/fr.json
+++ b/public/i18n/fr.json
@@ -28,5 +28,7 @@
   "parameter.load.error": "Erreur lors du chargement des paramètres",
   "parameter-station-mapping.load.error": "Missing value for 'parameter-station-mapping.load.error'",
   "map.load.error": "Missing value for 'map.load.error'",
-  "map.not-initialized.error": "Missing value for 'map.not-initialized.error'"
+  "map.not-initialized.error": "Missing value for 'map.not-initialized.error'",
+  "asset.load.error": "Missing value for 'asset.load.error'",
+  "asset.parse.error": "Missing value for 'asset.parse.error'"
 }

--- a/public/i18n/it.json
+++ b/public/i18n/it.json
@@ -28,5 +28,7 @@
   "parameter.load.error": "Errore durante il caricamento dei parametri",
   "parameter-station-mapping.load.error": "Missing value for 'parameter-station-mapping.load.error'",
   "map.load.error": "Missing value for 'map.load.error'",
-  "map.not-initialized.error": "Missing value for 'map.not-initialized.error'"
+  "map.not-initialized.error": "Missing value for 'map.not-initialized.error'",
+  "asset.load.error": "Missing value for 'asset.load.error'",
+  "asset.parse.error": "Missing value for 'asset.parse.error'"
 }

--- a/public/i18n/it.json
+++ b/public/i18n/it.json
@@ -30,5 +30,5 @@
   "map.load.error": "Missing value for 'map.load.error'",
   "map.not-initialized.error": "Missing value for 'map.not-initialized.error'",
   "asset.load.error": "Missing value for 'asset.load.error'",
-  "asset.parse.error": "Missing value for 'asset.parse.error'"
+  "asset.parse.error": "Errore durante l'analisi del file '{{filename}}'."
 }

--- a/src/app/error-handling/error-handler.service.ts
+++ b/src/app/error-handling/error-handler.service.ts
@@ -38,7 +38,7 @@ export class ErrorHandlerService implements ErrorHandler {
     }
   }
 
-  private showRecoverableErrorMessage(message: string): void {
+  private showRecoverableErrorMessage(_message: string): void {
     // TODO show error notification
   }
 

--- a/src/app/error-handling/error-handler.service.ts
+++ b/src/app/error-handling/error-handler.service.ts
@@ -27,19 +27,19 @@ export class ErrorHandlerService implements ErrorHandler {
         console.error('Original error was:', error.originalError);
       }
     }
-
-    const translatedMessage = this.translocoService.translate(error.message);
+    const translatedMessage =
+      error instanceof OpendataExplorerRuntimeError
+        ? this.translocoService.translate(error.message, error.translationArguments)
+        : error instanceof Error
+          ? error.message
+          : JSON.stringify(error);
     if (error instanceof SilentError) {
       // these errors should only be logged to a frontend logging service, but not displayed.
     } else if (error instanceof RecoverableError) {
-      this.showRecoverableErrorMessage(translatedMessage);
+      // At the moment, recoverable errors are treated the same as silent errors.
     } else {
       this.routeToErrorPage(translatedMessage);
     }
-  }
-
-  private showRecoverableErrorMessage(_message: string): void {
-    // TODO show error notification
   }
 
   private routeToErrorPage(message?: string): void {

--- a/src/app/shared/errors/asset.error.ts
+++ b/src/app/shared/errors/asset.error.ts
@@ -7,4 +7,11 @@ export class AssetLoadError extends SilentError {
 
 export class AssetParseError extends SilentError {
   public override message = marker('asset.parse.error');
+  public override translationArguments: Record<'filename', string>;
+
+  constructor(filename?: string, originalError?: unknown) {
+    super(originalError);
+
+    this.translationArguments = filename ? {filename} : {filename: 'Unknown file'};
+  }
 }

--- a/src/app/shared/errors/asset.error.ts
+++ b/src/app/shared/errors/asset.error.ts
@@ -1,0 +1,10 @@
+import {marker} from '@jsverse/transloco-keys-manager/marker';
+import {SilentError} from './base.error';
+
+export class AssetLoadError extends SilentError {
+  public override message = marker('asset.load.error');
+}
+
+export class AssetParseError extends SilentError {
+  public override message = marker('asset.parse.error');
+}

--- a/src/app/shared/errors/base.error.ts
+++ b/src/app/shared/errors/base.error.ts
@@ -1,5 +1,6 @@
 export abstract class OpendataExplorerRuntimeError extends Error {
   public readonly originalError?: unknown;
+  public translationArguments: Record<string, string> | undefined = undefined;
 
   constructor(originalError?: unknown) {
     super();

--- a/src/app/shared/models/date-range.ts
+++ b/src/app/shared/models/date-range.ts
@@ -1,0 +1,4 @@
+export interface DateRange {
+  start: Date;
+  end: Date;
+}

--- a/src/app/shared/models/station-assets.ts
+++ b/src/app/shared/models/station-assets.ts
@@ -1,0 +1,21 @@
+import {DateRange} from './date-range';
+import type {DataInterval} from './interval';
+import type {TimeRange} from './time-range';
+
+interface BaseStationAsset {
+  filename: string;
+  url: string;
+  interval: DataInterval;
+  timeRange: TimeRange;
+}
+
+interface HistoricalStationAsset extends BaseStationAsset {
+  timeRange: 'historical';
+  dateRange: DateRange | undefined;
+}
+
+interface NowAndRecentStationAsset extends BaseStationAsset {
+  timeRange: 'now' | 'recent';
+}
+
+export type StationAsset = HistoricalStationAsset | NowAndRecentStationAsset;

--- a/src/app/stac/models/stac-station-asset.ts
+++ b/src/app/stac/models/stac-station-asset.ts
@@ -1,0 +1,4 @@
+export interface StacStationAsset {
+  filename: string;
+  url: string | undefined;
+}

--- a/src/app/stac/service/asset.service.spec.ts
+++ b/src/app/stac/service/asset.service.spec.ts
@@ -1,3 +1,4 @@
+import {ErrorHandler} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 import {AssetService} from './asset.service';
 import {StacApiService} from './stac-api.service';
@@ -9,11 +10,19 @@ describe('AssetService', () => {
 
   beforeEach(() => {
     stacApiService = jasmine.createSpyObj<StacApiService>('StacApiService', ['getStationAssets']);
+    const errorHandler = jasmine.createSpyObj<ErrorHandler>('ErrorHandler', ['handleError']);
+    errorHandler.handleError.and.callFake((error) => {
+      throw error;
+    });
     TestBed.configureTestingModule({
       providers: [
         {
           provide: StacApiService,
           useValue: stacApiService,
+        },
+        {
+          provide: ErrorHandler,
+          useValue: errorHandler,
         },
       ],
     });
@@ -24,21 +33,27 @@ describe('AssetService', () => {
     const collection = 'collection';
     const stationId = 'stationId';
     stacApiService.getStationAssets.and.resolveTo([
-      {filename: `${collection}_${stationId}_t_now.csv`, url: ''},
-      {filename: `${collection}_${stationId}_m_recent.csv`, url: ''},
-      {filename: `${collection}_${stationId}_h_recent.csv`, url: ''},
-      {filename: `${collection}_${stationId}_d_recent.csv`, url: ''},
-      {filename: `${collection}_${stationId}_y_historical.csv`, url: ''},
+      {filename: `${collection}_${stationId}_t_now.csv`, url: 'google.com'},
+      {filename: `${collection}_${stationId}_m_recent.csv`, url: 'google.com'},
+      {filename: `${collection}_${stationId}_h_recent.csv`, url: 'google.com'},
+      {filename: `${collection}_${stationId}_d_recent.csv`, url: 'google.com'},
+      {filename: `${collection}_${stationId}_y_historical.csv`, url: 'google.com'},
     ]);
 
     const result = await service.loadStationAssets(collection, stationId);
 
     expect(result).toEqual([
-      {filename: `${collection}_${stationId}_t_now.csv`, url: '', interval: 'ten-minutes', timeRange: 'now'},
-      {filename: `${collection}_${stationId}_m_recent.csv`, url: '', interval: 'monthly', timeRange: 'recent'},
-      {filename: `${collection}_${stationId}_h_recent.csv`, url: '', interval: 'hourly', timeRange: 'recent'},
-      {filename: `${collection}_${stationId}_d_recent.csv`, url: '', interval: 'daily', timeRange: 'recent'},
-      {filename: `${collection}_${stationId}_y_historical.csv`, url: '', interval: 'yearly', timeRange: 'historical', dateRange: undefined},
+      {filename: `${collection}_${stationId}_t_now.csv`, url: 'google.com', interval: 'ten-minutes', timeRange: 'now'},
+      {filename: `${collection}_${stationId}_m_recent.csv`, url: 'google.com', interval: 'monthly', timeRange: 'recent'},
+      {filename: `${collection}_${stationId}_h_recent.csv`, url: 'google.com', interval: 'hourly', timeRange: 'recent'},
+      {filename: `${collection}_${stationId}_d_recent.csv`, url: 'google.com', interval: 'daily', timeRange: 'recent'},
+      {
+        filename: `${collection}_${stationId}_y_historical.csv`,
+        url: 'google.com',
+        interval: 'yearly',
+        timeRange: 'historical',
+        dateRange: undefined,
+      },
     ] satisfies StationAsset[]);
   });
 
@@ -46,9 +61,9 @@ describe('AssetService', () => {
     const collection = 'collection';
     const stationId = 'stationId';
     stacApiService.getStationAssets.and.resolveTo([
-      {filename: `${collection}_${stationId}_t_historical_19910101_20001231.csv`, url: ''},
-      {filename: `${collection}_${stationId}_t_historical_20010101_20101231.csv`, url: ''},
-      {filename: `${collection}_${stationId}_t_historical_20110101_20201231.csv`, url: ''},
+      {filename: `${collection}_${stationId}_t_historical_19910101_20001231.csv`, url: 'google.com'},
+      {filename: `${collection}_${stationId}_t_historical_20010101_20101231.csv`, url: 'google.com'},
+      {filename: `${collection}_${stationId}_t_historical_20110101_20201231.csv`, url: 'google.com'},
     ]);
 
     const result = await service.loadStationAssets(collection, stationId);
@@ -57,21 +72,21 @@ describe('AssetService', () => {
       jasmine.arrayWithExactContents([
         {
           filename: `${collection}_${stationId}_t_historical_19910101_20001231.csv`,
-          url: '',
+          url: 'google.com',
           interval: 'ten-minutes',
           timeRange: 'historical',
           dateRange: {start: jasmine.any(Date), end: jasmine.any(Date)},
         },
         {
           filename: `${collection}_${stationId}_t_historical_20010101_20101231.csv`,
-          url: '',
+          url: 'google.com',
           interval: 'ten-minutes',
           timeRange: 'historical',
           dateRange: {start: jasmine.any(Date), end: jasmine.any(Date)},
         },
         {
           filename: `${collection}_${stationId}_t_historical_20110101_20201231.csv`,
-          url: '',
+          url: 'google.com',
           interval: 'ten-minutes',
           timeRange: 'historical',
           dateRange: {start: jasmine.any(Date), end: jasmine.any(Date)},
@@ -83,7 +98,9 @@ describe('AssetService', () => {
   it('should parse dates correctly', async () => {
     const collection = 'collection';
     const stationId = 'stationId';
-    stacApiService.getStationAssets.and.resolveTo([{filename: `${collection}_${stationId}_t_historical_19910101_20001231.csv`, url: ''}]);
+    stacApiService.getStationAssets.and.resolveTo([
+      {filename: `${collection}_${stationId}_t_historical_19910101_20001231.csv`, url: 'google.com'},
+    ]);
 
     const result = await service.loadStationAssets(collection, stationId);
 

--- a/src/app/stac/service/asset.service.spec.ts
+++ b/src/app/stac/service/asset.service.spec.ts
@@ -33,23 +33,23 @@ describe('AssetService', () => {
     const collection = 'collection';
     const stationId = 'stationId';
     stacApiService.getStationAssets.and.resolveTo([
-      {filename: `${collection}_${stationId}_t_now.csv`, url: 'google.com'},
-      {filename: `${collection}_${stationId}_m_recent.csv`, url: 'google.com'},
-      {filename: `${collection}_${stationId}_h_recent.csv`, url: 'google.com'},
-      {filename: `${collection}_${stationId}_d_recent.csv`, url: 'google.com'},
-      {filename: `${collection}_${stationId}_y_historical.csv`, url: 'google.com'},
+      {filename: `${collection}_${stationId}_t_now.csv`, url: 'www.meteoschweiz.admin.ch'},
+      {filename: `${collection}_${stationId}_m_recent.csv`, url: 'www.meteoschweiz.admin.ch'},
+      {filename: `${collection}_${stationId}_h_recent.csv`, url: 'www.meteoschweiz.admin.ch'},
+      {filename: `${collection}_${stationId}_d_recent.csv`, url: 'www.meteoschweiz.admin.ch'},
+      {filename: `${collection}_${stationId}_y_historical.csv`, url: 'www.meteoschweiz.admin.ch'},
     ]);
 
     const result = await service.loadStationAssets(collection, stationId);
 
     expect(result).toEqual([
-      {filename: `${collection}_${stationId}_t_now.csv`, url: 'google.com', interval: 'ten-minutes', timeRange: 'now'},
-      {filename: `${collection}_${stationId}_m_recent.csv`, url: 'google.com', interval: 'monthly', timeRange: 'recent'},
-      {filename: `${collection}_${stationId}_h_recent.csv`, url: 'google.com', interval: 'hourly', timeRange: 'recent'},
-      {filename: `${collection}_${stationId}_d_recent.csv`, url: 'google.com', interval: 'daily', timeRange: 'recent'},
+      {filename: `${collection}_${stationId}_t_now.csv`, url: 'www.meteoschweiz.admin.ch', interval: 'ten-minutes', timeRange: 'now'},
+      {filename: `${collection}_${stationId}_m_recent.csv`, url: 'www.meteoschweiz.admin.ch', interval: 'monthly', timeRange: 'recent'},
+      {filename: `${collection}_${stationId}_h_recent.csv`, url: 'www.meteoschweiz.admin.ch', interval: 'hourly', timeRange: 'recent'},
+      {filename: `${collection}_${stationId}_d_recent.csv`, url: 'www.meteoschweiz.admin.ch', interval: 'daily', timeRange: 'recent'},
       {
         filename: `${collection}_${stationId}_y_historical.csv`,
-        url: 'google.com',
+        url: 'www.meteoschweiz.admin.ch',
         interval: 'yearly',
         timeRange: 'historical',
         dateRange: undefined,
@@ -61,9 +61,9 @@ describe('AssetService', () => {
     const collection = 'collection';
     const stationId = 'stationId';
     stacApiService.getStationAssets.and.resolveTo([
-      {filename: `${collection}_${stationId}_t_historical_19910101_20001231.csv`, url: 'google.com'},
-      {filename: `${collection}_${stationId}_t_historical_20010101_20101231.csv`, url: 'google.com'},
-      {filename: `${collection}_${stationId}_t_historical_20110101_20201231.csv`, url: 'google.com'},
+      {filename: `${collection}_${stationId}_t_historical_19910101_20001231.csv`, url: 'www.meteoschweiz.admin.ch'},
+      {filename: `${collection}_${stationId}_t_historical_20010101_20101231.csv`, url: 'www.meteoschweiz.admin.ch'},
+      {filename: `${collection}_${stationId}_t_historical_20110101_20201231.csv`, url: 'www.meteoschweiz.admin.ch'},
     ]);
 
     const result = await service.loadStationAssets(collection, stationId);
@@ -72,21 +72,21 @@ describe('AssetService', () => {
       jasmine.arrayWithExactContents([
         {
           filename: `${collection}_${stationId}_t_historical_19910101_20001231.csv`,
-          url: 'google.com',
+          url: 'www.meteoschweiz.admin.ch',
           interval: 'ten-minutes',
           timeRange: 'historical',
           dateRange: {start: jasmine.any(Date), end: jasmine.any(Date)},
         },
         {
           filename: `${collection}_${stationId}_t_historical_20010101_20101231.csv`,
-          url: 'google.com',
+          url: 'www.meteoschweiz.admin.ch',
           interval: 'ten-minutes',
           timeRange: 'historical',
           dateRange: {start: jasmine.any(Date), end: jasmine.any(Date)},
         },
         {
           filename: `${collection}_${stationId}_t_historical_20110101_20201231.csv`,
-          url: 'google.com',
+          url: 'www.meteoschweiz.admin.ch',
           interval: 'ten-minutes',
           timeRange: 'historical',
           dateRange: {start: jasmine.any(Date), end: jasmine.any(Date)},
@@ -99,7 +99,7 @@ describe('AssetService', () => {
     const collection = 'collection';
     const stationId = 'stationId';
     stacApiService.getStationAssets.and.resolveTo([
-      {filename: `${collection}_${stationId}_t_historical_19910101_20001231.csv`, url: 'google.com'},
+      {filename: `${collection}_${stationId}_t_historical_19910101_20001231.csv`, url: 'www.meteoschweiz.admin.ch'},
     ]);
 
     const result = await service.loadStationAssets(collection, stationId);

--- a/src/app/stac/service/asset.service.spec.ts
+++ b/src/app/stac/service/asset.service.spec.ts
@@ -1,0 +1,98 @@
+import {TestBed} from '@angular/core/testing';
+import {AssetService} from './asset.service';
+import {StacApiService} from './stac-api.service';
+import type {StationAsset} from '../../shared/models/station-assets';
+
+describe('AssetService', () => {
+  let service: AssetService;
+  let stacApiService: jasmine.SpyObj<StacApiService>;
+
+  beforeEach(() => {
+    stacApiService = jasmine.createSpyObj<StacApiService>('StacApiService', ['getStationAssets']);
+    TestBed.configureTestingModule({
+      providers: [
+        {
+          provide: StacApiService,
+          useValue: stacApiService,
+        },
+      ],
+    });
+    service = TestBed.inject(AssetService);
+  });
+
+  it('should get the assets for a station form the stacApiService and parse the filename', async () => {
+    const collection = 'collection';
+    const stationId = 'stationId';
+    stacApiService.getStationAssets.and.resolveTo([
+      {filename: `${collection}_${stationId}_t_now.csv`, url: ''},
+      {filename: `${collection}_${stationId}_m_recent.csv`, url: ''},
+      {filename: `${collection}_${stationId}_h_recent.csv`, url: ''},
+      {filename: `${collection}_${stationId}_d_recent.csv`, url: ''},
+      {filename: `${collection}_${stationId}_y_historical.csv`, url: ''},
+    ]);
+
+    const result = await service.loadStationAssets(collection, stationId);
+
+    expect(result).toEqual([
+      {filename: `${collection}_${stationId}_t_now.csv`, url: '', interval: 'ten-minutes', timeRange: 'now'},
+      {filename: `${collection}_${stationId}_m_recent.csv`, url: '', interval: 'monthly', timeRange: 'recent'},
+      {filename: `${collection}_${stationId}_h_recent.csv`, url: '', interval: 'hourly', timeRange: 'recent'},
+      {filename: `${collection}_${stationId}_d_recent.csv`, url: '', interval: 'daily', timeRange: 'recent'},
+      {filename: `${collection}_${stationId}_y_historical.csv`, url: '', interval: 'yearly', timeRange: 'historical', dateRange: undefined},
+    ] satisfies StationAsset[]);
+  });
+
+  it('should parse assets with explicit time range', async () => {
+    const collection = 'collection';
+    const stationId = 'stationId';
+    stacApiService.getStationAssets.and.resolveTo([
+      {filename: `${collection}_${stationId}_t_historical_19910101_20001231.csv`, url: ''},
+      {filename: `${collection}_${stationId}_t_historical_20010101_20101231.csv`, url: ''},
+      {filename: `${collection}_${stationId}_t_historical_20110101_20201231.csv`, url: ''},
+    ]);
+
+    const result = await service.loadStationAssets(collection, stationId);
+
+    expect(result).toEqual(
+      jasmine.arrayWithExactContents([
+        {
+          filename: `${collection}_${stationId}_t_historical_19910101_20001231.csv`,
+          url: '',
+          interval: 'ten-minutes',
+          timeRange: 'historical',
+          dateRange: {start: jasmine.any(Date), end: jasmine.any(Date)},
+        },
+        {
+          filename: `${collection}_${stationId}_t_historical_20010101_20101231.csv`,
+          url: '',
+          interval: 'ten-minutes',
+          timeRange: 'historical',
+          dateRange: {start: jasmine.any(Date), end: jasmine.any(Date)},
+        },
+        {
+          filename: `${collection}_${stationId}_t_historical_20110101_20201231.csv`,
+          url: '',
+          interval: 'ten-minutes',
+          timeRange: 'historical',
+          dateRange: {start: jasmine.any(Date), end: jasmine.any(Date)},
+        },
+      ]),
+    );
+  });
+
+  it('should parse dates correctly', async () => {
+    const collection = 'collection';
+    const stationId = 'stationId';
+    stacApiService.getStationAssets.and.resolveTo([{filename: `${collection}_${stationId}_t_historical_19910101_20001231.csv`, url: ''}]);
+
+    const result = await service.loadStationAssets(collection, stationId);
+
+    expect(result).toEqual(
+      jasmine.arrayWithExactContents([
+        jasmine.objectContaining({
+          dateRange: {start: new Date('1991-01-01T00:00'), end: new Date('2000-12-31T00:00')},
+        }),
+      ]),
+    );
+  });
+});

--- a/src/app/stac/service/asset.service.ts
+++ b/src/app/stac/service/asset.service.ts
@@ -1,0 +1,102 @@
+import {inject, Injectable} from '@angular/core';
+import {AssetParseError} from '../../shared/errors/asset.error';
+import {isTimeRange} from '../../shared/type-guards/time-range-guard';
+import {StacApiService} from './stac-api.service';
+import type {DataInterval} from '../../shared/models/interval';
+import type {StationAsset} from '../../shared/models/station-assets';
+import type {TimeRange} from '../../shared/models/time-range';
+import type {StacStationAsset} from '../models/stac-station-asset';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class AssetService {
+  private readonly stacApiService = inject(StacApiService);
+
+  private readonly parseRegex =
+    /^(?<collectionId>[^_]+)_(?<stationId>[^_]+)_(?<interval>[^_]+)_(?<timeRange>[^_]+)(?:_(?<fromDate>\d{8})_(?<toDate>\d{8}))?\.csv$/;
+
+  public async loadStationAssets(collection: string, stationId: string): Promise<StationAsset[]> {
+    const assets = await this.stacApiService.getStationAssets(collection, stationId);
+    return assets
+      .map((asset) => {
+        try {
+          return this.parseStacStationAsset(asset);
+        } catch (error: unknown) {
+          console.error(error);
+          return undefined;
+        }
+      })
+      .filter((asset) => asset != null);
+  }
+
+  private parseStacStationAsset(asset: StacStationAsset): StationAsset {
+    const matches = RegExp(this.parseRegex).exec(asset.filename);
+    if (!matches) {
+      // TODO: Error handling
+      throw new AssetParseError();
+    }
+
+    const interval = this.transformInterval(matches.groups?.['interval'] as string);
+    const timeRange = this.transformTimeRange(matches.groups?.['timeRange'] as string);
+
+    if (timeRange === 'historical') {
+      const fromDate = this.transformDate(matches.groups?.['fromDate']);
+      const toDate = this.transformDate(matches.groups?.['toDate']);
+      const dataRange = fromDate != null && toDate != null ? {start: fromDate, end: toDate} : undefined;
+      return {
+        filename: asset.filename,
+        url: asset.url ?? '',
+        interval,
+        timeRange: timeRange,
+        dateRange: dataRange,
+      };
+    } else {
+      return {
+        filename: asset.filename,
+        url: asset.url ?? '',
+        interval,
+        timeRange: timeRange,
+      };
+    }
+  }
+
+  private transformInterval(interval: string): DataInterval {
+    switch (interval) {
+      case 't':
+        return 'ten-minutes';
+      case 'd':
+        return 'daily';
+      case 'm':
+        return 'monthly';
+      case 'y':
+        return 'yearly';
+      case 'h':
+        return 'hourly';
+      default:
+        // TODO: Error handling
+        throw new AssetParseError();
+    }
+  }
+
+  private transformTimeRange(timeRange: string): TimeRange {
+    if (isTimeRange(timeRange)) {
+      return timeRange;
+    }
+    // TODO: Error handling
+    throw new AssetParseError();
+  }
+
+  private transformDate(date: string | undefined): Date | undefined {
+    // TODO: Error handling
+    if (!date) {
+      return undefined;
+    }
+    const year = date.substring(0, 4);
+    const month = date.substring(4, 6);
+    const day = date.substring(6, 8);
+
+    // Note: months are 0-indexed in JavaScript Date objects
+    return new Date(Number(year), Number(month) - 1, Number(day));
+  }
+}

--- a/src/app/stac/service/asset.service.ts
+++ b/src/app/stac/service/asset.service.ts
@@ -25,7 +25,7 @@ export class AssetService {
           return this.parseStacStationAsset(asset);
         } catch (error: unknown) {
           if (error instanceof AssetParseError) {
-            error.translationArguments = {filename: asset.filename};
+            error.translationArguments.filename = asset.filename;
           }
           this.errorHandler.handleError(error);
           return undefined;
@@ -36,12 +36,12 @@ export class AssetService {
 
   private parseStacStationAsset(asset: StacStationAsset): StationAsset {
     if (!asset.url) {
-      throw new AssetParseError();
+      throw new AssetParseError(asset.filename);
     }
 
     const matches = RegExp(this.parseRegex).exec(asset.filename);
     if (!matches || !matches.groups) {
-      throw new AssetParseError();
+      throw new AssetParseError(asset.filename);
     }
 
     const interval = this.transformInterval(matches.groups['interval']);
@@ -96,7 +96,7 @@ export class AssetService {
   }
 
   private transformDate(date: string | undefined): Date | undefined {
-    if (!date) {
+    if (!date || date.length < 8) {
       return undefined;
     }
     const year = Number(date.substring(0, 4));

--- a/src/app/stac/service/data-inventory.service.spec.ts
+++ b/src/app/stac/service/data-inventory.service.spec.ts
@@ -1,5 +1,4 @@
 import {TestBed} from '@angular/core/testing';
-import {provideMockStore} from '@ngrx/store/testing';
 import {ParameterStationMapping} from '../../shared/models/parameter-station-mapping';
 import {CsvDataInventory} from '../models/csv-data-inventory';
 import {DataInventoryService} from './data-inventory.service';
@@ -32,7 +31,6 @@ describe('DataInventoryService', () => {
 
     TestBed.configureTestingModule({
       providers: [
-        provideMockStore(),
         {
           provide: StacApiService,
           useValue: stacApiService,

--- a/src/app/stac/service/parameter.service.spec.ts
+++ b/src/app/stac/service/parameter.service.spec.ts
@@ -1,5 +1,4 @@
 import {TestBed} from '@angular/core/testing';
-import {provideMockStore} from '@ngrx/store/testing';
 import {CsvParameter} from '../models/csv-parameter';
 import {ParameterService} from './parameter.service';
 import {StacApiService} from './stac-api.service';
@@ -43,7 +42,6 @@ describe('ParameterService', () => {
 
     TestBed.configureTestingModule({
       providers: [
-        provideMockStore(),
         {
           provide: StacApiService,
           useValue: stacApiService,

--- a/src/app/stac/service/station.service.spec.ts
+++ b/src/app/stac/service/station.service.spec.ts
@@ -1,5 +1,4 @@
 import {TestBed} from '@angular/core/testing';
-import {provideMockStore} from '@ngrx/store/testing';
 import {StacApiService} from './stac-api.service';
 import {StationService} from './station.service';
 import type {Station} from '../../shared/models/station';
@@ -59,7 +58,6 @@ describe('StationService', () => {
     stacApiService = jasmine.createSpyObj<StacApiService>('StacApiService', ['getCollectionMetaCsvFile']);
     TestBed.configureTestingModule({
       providers: [
-        provideMockStore(),
         {
           provide: StacApiService,
           useValue: stacApiService,

--- a/src/app/state/assets/actions/asset.actions.ts
+++ b/src/app/state/assets/actions/asset.actions.ts
@@ -1,0 +1,13 @@
+import {createActionGroup, emptyProps, props} from '@ngrx/store';
+import {StationAsset} from '../../../shared/models/station-assets';
+import {errorProps} from '../../utils/error-props.util';
+
+export const assetActions = createActionGroup({
+  source: 'Asset',
+  events: {
+    'Load assets for station': props<{stationId: string; collection: string}>(),
+    'Set loaded assets': props<{assets: StationAsset[] | undefined}>(),
+    'Set asset loading error': errorProps(),
+    'Reset state': emptyProps(),
+  },
+});

--- a/src/app/state/assets/effects/asset.effects.spec.ts
+++ b/src/app/state/assets/effects/asset.effects.spec.ts
@@ -1,0 +1,120 @@
+import {TestBed} from '@angular/core/testing';
+import {Action} from '@ngrx/store';
+import {MockStore, provideMockStore} from '@ngrx/store/testing';
+import {catchError, EMPTY, Observable, of} from 'rxjs';
+import {AssetLoadError} from '../../../shared/errors/asset.error';
+import {StationAsset} from '../../../shared/models/station-assets';
+import {OpendataExplorerRuntimeErrorTestUtil} from '../../../shared/testing/utils/opendata-explorer-runtime-error-test.util';
+import {AssetService} from '../../../stac/service/asset.service';
+import {formActions} from '../../form/actions/form.actions';
+import {formFeature} from '../../form/reducers/form.reducer';
+import {FormState} from '../../form/states/form.state';
+import {assetActions} from '../actions/asset.actions';
+import {failLoadingAssets, loadAssetsForStation} from './asset.effects';
+
+describe('AssetEffects', () => {
+  let actions$: Observable<Action>;
+  let store: MockStore;
+  let assetService: AssetService;
+
+  beforeEach(() => {
+    actions$ = new Observable<Action>();
+    TestBed.configureTestingModule({
+      providers: [provideMockStore()],
+    });
+    store = TestBed.inject(MockStore);
+    assetService = TestBed.inject(AssetService);
+  });
+
+  afterEach(() => {
+    store.resetSelectors();
+  });
+
+  describe('loadAssetsForStation', () => {
+    it('should dispatch setLoadedAssets after successfully loading assets', (done: DoneFn) => {
+      const assets: StationAsset[] = [
+        {
+          timeRange: 'recent',
+          url: 'testUrl',
+          filename: 'testFilename',
+          interval: 'monthly',
+        },
+      ];
+      store.overrideSelector(formFeature.selectFormState, {
+        selectedStationId: 'testStationId',
+        selectedCollection: 'testCollection',
+      } as FormState);
+      spyOn(assetService, 'loadStationAssets').and.resolveTo(assets);
+      actions$ = of(formActions.setSelectedCollection({collection: 'testCollection'}));
+
+      loadAssetsForStation(actions$, store, assetService).subscribe((action) => {
+        expect(assetService.loadStationAssets).toHaveBeenCalledOnceWith('testCollection', 'testStationId');
+        expect(action).toEqual(assetActions.setLoadedAssets({assets}));
+        done();
+      });
+    });
+
+    it('should dispatch setAssetLoadingError if the service throws an error during loading', (done: DoneFn) => {
+      const error = new Error('test');
+      spyOn(assetService, 'loadStationAssets').and.rejectWith(error);
+      store.overrideSelector(formFeature.selectFormState, {
+        selectedStationId: 'testStationId',
+        selectedCollection: 'testCollection',
+      } as FormState);
+      actions$ = of(formActions.setSelectedCollection({collection: 'testCollection'}));
+
+      loadAssetsForStation(actions$, store, assetService).subscribe((action) => {
+        expect(action).toEqual(assetActions.setAssetLoadingError({error}));
+        done();
+      });
+    });
+
+    it('should call the assetService if the given stationId is null', (done) => {
+      spyOn(assetService, 'loadStationAssets');
+      store.overrideSelector(formFeature.selectFormState, {
+        selectedStationId: null,
+        selectedCollection: 'testCollection',
+      } as FormState);
+      actions$ = of(formActions.setSelectedCollection({collection: 'testCollection'}));
+
+      loadAssetsForStation(actions$, store, assetService).subscribe({
+        complete: () => {
+          expect(assetService.loadStationAssets).not.toHaveBeenCalled();
+          done();
+        },
+      });
+    });
+
+    it('should call the assetService if the given collection is null', (done) => {
+      spyOn(assetService, 'loadStationAssets');
+      store.overrideSelector(formFeature.selectFormState, {
+        selectedStationId: 'testStationId',
+        selectedCollection: null,
+      } as FormState);
+      actions$ = of(formActions.setSelectedCollection({collection: null}));
+
+      loadAssetsForStation(actions$, store, assetService).subscribe({
+        complete: () => {
+          expect(assetService.loadStationAssets).not.toHaveBeenCalled();
+          done();
+        },
+      });
+    });
+  });
+
+  it('should throw a AssetLoadError after dispatching setAssetLoadingError', (done: DoneFn) => {
+    const error = new Error('My cabbages!!!');
+    const expectedError = new AssetLoadError(error);
+
+    actions$ = of(assetActions.setAssetLoadingError({error}));
+    failLoadingAssets(actions$)
+      .pipe(
+        catchError((caughtError: unknown) => {
+          OpendataExplorerRuntimeErrorTestUtil.expectToDeepEqual(caughtError, expectedError);
+          done();
+          return EMPTY;
+        }),
+      )
+      .subscribe();
+  });
+});

--- a/src/app/state/assets/effects/asset.effects.ts
+++ b/src/app/state/assets/effects/asset.effects.ts
@@ -1,0 +1,56 @@
+import {inject} from '@angular/core';
+import {Actions, createEffect, ofType} from '@ngrx/effects';
+import {concatLatestFrom} from '@ngrx/operators';
+import {Store} from '@ngrx/store';
+import {catchError, distinctUntilChanged, filter, from, map, of, switchMap, tap} from 'rxjs';
+import {AssetLoadError} from '../../../shared/errors/asset.error';
+import {AssetService} from '../../../stac/service/asset.service';
+import {formActions} from '../../form/actions/form.actions';
+import {formFeature} from '../../form/reducers/form.reducer';
+import {assetActions} from '../actions/asset.actions';
+
+export const loadAssetsForStation = createEffect(
+  (actions$ = inject(Actions), store = inject(Store), assetService = inject(AssetService)) => {
+    return actions$.pipe(
+      ofType(formActions.setSelectedCollection, formActions.setSelectedParameterGroupAndStationIdAndCollection),
+      concatLatestFrom(() => store.select(formFeature.selectFormState)),
+      map(([_, {selectedStationId, selectedCollection}]) => ({selectedStationId, selectedCollection})),
+      // use distinctUntilChanged to prevent unnecessary API calls
+      distinctUntilChanged(
+        (prev, curr) => prev.selectedStationId === curr.selectedStationId && prev.selectedCollection === curr.selectedCollection,
+      ),
+      filter(({selectedStationId, selectedCollection}) => !!selectedStationId && !!selectedCollection),
+      switchMap(({selectedStationId, selectedCollection}) =>
+        from(assetService.loadStationAssets(selectedCollection!, selectedStationId!)).pipe(
+          map((assets) => assetActions.setLoadedAssets({assets})),
+          catchError((error: unknown) => of(assetActions.setAssetLoadingError({error}))),
+        ),
+      ),
+    );
+  },
+  {functional: true},
+);
+
+export const resetAssets = createEffect(
+  (actions$ = inject(Actions), store = inject(Store)) => {
+    return actions$.pipe(
+      ofType(formActions.setSelectedCollection, formActions.setSelectedParameterGroupAndStationIdAndCollection),
+      concatLatestFrom(() => store.select(formFeature.selectFormState)),
+      filter(([, {selectedStationId, selectedCollection}]) => !selectedStationId || !selectedCollection),
+      map(() => assetActions.resetState()),
+    );
+  },
+  {functional: true},
+);
+
+export const failLoadingAssets = createEffect(
+  (actions$ = inject(Actions)) => {
+    return actions$.pipe(
+      ofType(assetActions.setAssetLoadingError),
+      tap(({error}) => {
+        throw new AssetLoadError(error);
+      }),
+    );
+  },
+  {functional: true, dispatch: false},
+);

--- a/src/app/state/assets/reducers/asset.reducer.spec.ts
+++ b/src/app/state/assets/reducers/asset.reducer.spec.ts
@@ -1,0 +1,65 @@
+import {StationAsset} from '../../../shared/models/station-assets';
+import {assetActions} from '../actions/asset.actions';
+import {AssetState} from '../states/asset.state';
+import {assetFeature, initialState} from './asset.reducer';
+
+describe('Asset Reducer', () => {
+  let state: AssetState;
+
+  beforeEach(() => {
+    state = {
+      loadingState: 'loading',
+      assets: [],
+    };
+  });
+
+  it('should set loadingState to loading when loadAssetsForStation is dispatched', () => {
+    state.loadingState = 'error';
+    const action = assetActions.loadAssetsForStation({stationId: 'testStationId', collection: 'testCollection'});
+
+    const result = assetFeature.reducer(state, action);
+
+    expect(result).toEqual({
+      ...initialState,
+      loadingState: 'loading',
+    });
+  });
+
+  it('should set assets and loadingState to loaded when setLoadedAssets is dispatched', () => {
+    const assets: StationAsset[] = [
+      {
+        timeRange: 'recent',
+        url: 'testUrl',
+        filename: 'testFilename',
+        interval: 'monthly',
+      },
+    ];
+    const action = assetActions.setLoadedAssets({assets});
+
+    const result = assetFeature.reducer(state, action);
+
+    expect(result).toEqual({
+      loadingState: 'loaded',
+      assets,
+    });
+  });
+
+  it('should reset to initialState and set loadingState to error when setAssetLoadingError is dispatched', () => {
+    const action = assetActions.setAssetLoadingError({});
+
+    const result = assetFeature.reducer(state, action);
+
+    expect(result).toEqual({
+      ...initialState,
+      loadingState: 'error',
+    });
+  });
+
+  it('should reset to initialState when resetState is dispatched', () => {
+    const action = assetActions.resetState();
+
+    const result = assetFeature.reducer(state, action);
+
+    expect(result).toEqual(initialState);
+  });
+});

--- a/src/app/state/assets/reducers/asset.reducer.ts
+++ b/src/app/state/assets/reducers/asset.reducer.ts
@@ -1,0 +1,21 @@
+import {createFeature, createReducer, on} from '@ngrx/store';
+import {assetActions} from '../actions/asset.actions';
+import {AssetState} from '../states/asset.state';
+
+export const assetFeatureKey = 'asset';
+
+export const initialState: AssetState = {
+  assets: undefined,
+  loadingState: undefined,
+};
+
+export const assetFeature = createFeature({
+  name: assetFeatureKey,
+  reducer: createReducer(
+    initialState,
+    on(assetActions.loadAssetsForStation, (): AssetState => ({...initialState, loadingState: 'loading'})),
+    on(assetActions.setLoadedAssets, (state, {assets}): AssetState => ({...state, assets, loadingState: 'loaded'})),
+    on(assetActions.setAssetLoadingError, (): AssetState => ({...initialState, loadingState: 'error'})),
+    on(assetActions.resetState, (): AssetState => ({...initialState})),
+  ),
+});

--- a/src/app/state/assets/states/asset.state.ts
+++ b/src/app/state/assets/states/asset.state.ts
@@ -1,0 +1,6 @@
+import {LoadableState} from '../../../shared/models/loadable-state';
+import type {StationAsset} from '../../../shared/models/station-assets';
+
+export interface AssetState extends LoadableState {
+  assets: StationAsset[] | undefined;
+}

--- a/src/app/state/index.ts
+++ b/src/app/state/index.ts
@@ -3,6 +3,9 @@ import * as appEffects from './app/effects/app.effects';
 import * as urlParameterEffects from './app/effects/url-parameter.effects';
 import {appFeature, appFeatureKey} from './app/reducers/app.reducer';
 import {AppState} from './app/states/app.state';
+import * as assertEffects from './assets/effects/asset.effects';
+import {assetFeature, assetFeatureKey} from './assets/reducers/asset.reducer';
+import {AssetState} from './assets/states/asset.state';
 import * as formEffects from './form/effects/form.effects';
 import {formFeature, formFeatureKey} from './form/reducers/form.reducer';
 import * as mapEffects from './map/effects/map.effects';
@@ -33,6 +36,7 @@ export interface State {
   [mapFeatureKey]: MapState;
   [appFeatureKey]: AppState;
   router: RouterState;
+  [assetFeatureKey]: AssetState;
 }
 export const reducers: ActionReducerMap<State> = {
   [parameterFeatureKey]: parameterFeature.reducer,
@@ -42,6 +46,7 @@ export const reducers: ActionReducerMap<State> = {
   [mapFeatureKey]: mapFeature.reducer,
   [appFeatureKey]: appFeature.reducer,
   router: routerReducer,
+  [assetFeatureKey]: assetFeature.reducer,
 };
 export const effects: (Type<unknown> | Record<string, FunctionalEffect>)[] = [
   parameterEffects,
@@ -51,5 +56,6 @@ export const effects: (Type<unknown> | Record<string, FunctionalEffect>)[] = [
   formEffects,
   appEffects,
   urlParameterEffects,
+  assertEffects,
 ];
 export const metaReducers: MetaReducer<State>[] = [];


### PR DESCRIPTION
This PR add functionality to load station assets from the STAC-API. 

This service retrieves all assets for a given station and collection
from the stac API. As only the asset filenames and urls are needed we
only use these values. Then we extract some information from the
filenames for which the format is predefined.

The errors in this service are inherited from `SilentError`
Failing to load an asset should not crash the application in contrast to
our previous errors while loading the stations, parameters or their
mapping which is essential to the application.

Assets are now loaded automatically when a collection is set because at
that point we have all necessary information (station ID + collection).
The effect for loading the assets is slightly different than our usual
approach: it loads new assets independent from the loading state. It
does not matter if any other assets are already loaded.

Also any change to station ID or collection will either result in a
new request or the state will be reset as it heavily depends on the
currently selected station and collection.