### PR TITLE
Put collection assets in store and use them to load all other data #32

### DIFF
--- a/public/i18n/de.json
+++ b/public/i18n/de.json
@@ -25,6 +25,7 @@
   "download-metadata": "Missing value for 'download-metadata'",
   "form.collection-selection.parameter-groups": "Missing value for 'form.collection-selection.parameter-groups'",
   "station.load.error": "Missing value for 'station.load.error'",
+  "stac.load.error": "Es konnten keine Assets für collectionId '{{collectionId}}' und stationId '{{stationId}}' abgerufen werden",
   "parameter.load.error": "Fehler beim Laden der Parameter",
   "parameter-station-mapping.load.error": "Missing value for 'parameter-station-mapping.load.error'",
   "map.load.error": "Missing value for 'map.load.error'",

--- a/public/i18n/de.json
+++ b/public/i18n/de.json
@@ -29,6 +29,7 @@
   "parameter-station-mapping.load.error": "Missing value for 'parameter-station-mapping.load.error'",
   "map.load.error": "Missing value for 'map.load.error'",
   "map.not-initialized.error": "Missing value for 'map.not-initialized.error'",
+  "collection.load.error": "Missing value for 'collection.load.error'",
   "asset.load.error": "Missing value for 'asset.load.error'",
   "asset.parse.error": "Fehler beim lesen der Datei '{{filename}}'"
 }

--- a/public/i18n/en.json
+++ b/public/i18n/en.json
@@ -25,6 +25,7 @@
   "download-metadata": "Missing value for 'download-metadata'",
   "form.collection-selection.parameter-groups": "Missing value for 'form.collection-selection.parameter-groups'",
   "station.load.error": "Missing value for 'station.load.error'",
+  "stac.load.error": "Failed to get assets for collectionId '{{collectionId}}' and stationId '{{stationId}}'",
   "parameter.load.error": "Error loading parameters",
   "parameter-station-mapping.load.error": "Missing value for 'parameter-station-mapping.load.error'",
   "map.load.error": "Missing value for 'map.load.error'",

--- a/public/i18n/en.json
+++ b/public/i18n/en.json
@@ -29,6 +29,7 @@
   "parameter-station-mapping.load.error": "Missing value for 'parameter-station-mapping.load.error'",
   "map.load.error": "Missing value for 'map.load.error'",
   "map.not-initialized.error": "Missing value for 'map.not-initialized.error'",
+  "collection.load.error": "Missing value for 'collection.load.error'",
   "asset.load.error": "Missing value for 'asset.load.error'",
   "asset.parse.error": "Error while parsing file '{{filename}}'"
 }

--- a/public/i18n/fr.json
+++ b/public/i18n/fr.json
@@ -29,6 +29,7 @@
   "parameter-station-mapping.load.error": "Missing value for 'parameter-station-mapping.load.error'",
   "map.load.error": "Missing value for 'map.load.error'",
   "map.not-initialized.error": "Missing value for 'map.not-initialized.error'",
+  "collection.load.error": "Missing value for 'collection.load.error'",
   "asset.load.error": "Missing value for 'asset.load.error'",
   "asset.parse.error": "Erreur lors de l'analyse du fichier '{{filename}}''"
 }

--- a/public/i18n/fr.json
+++ b/public/i18n/fr.json
@@ -25,6 +25,7 @@
   "download-metadata": "Missing value for 'download-metadata'",
   "form.collection-selection.parameter-groups": "Missing value for 'form.collection-selection.parameter-groups'",
   "station.load.error": "Missing value for 'station.load.error'",
+  "stac.load.error": "Échec de la récupération des actifs pour collectionId '{{collectionId}}' et stationId '{{stationId}}'",
   "parameter.load.error": "Erreur lors du chargement des paramètres",
   "parameter-station-mapping.load.error": "Missing value for 'parameter-station-mapping.load.error'",
   "map.load.error": "Missing value for 'map.load.error'",

--- a/public/i18n/it.json
+++ b/public/i18n/it.json
@@ -25,6 +25,7 @@
   "download-metadata": "Missing value for 'download-metadata'",
   "form.collection-selection.parameter-groups": "Missing value for 'form.collection-selection.parameter-groups'",
   "station.load.error": "Missing value for 'station.load.error'",
+  "stac.load.error": "Impossibile ottenere le risorse per collectionId '{{collectionId}}' e stationId '{{stationId}}'",
   "parameter.load.error": "Errore durante il caricamento dei parametri",
   "parameter-station-mapping.load.error": "Missing value for 'parameter-station-mapping.load.error'",
   "map.load.error": "Missing value for 'map.load.error'",

--- a/public/i18n/it.json
+++ b/public/i18n/it.json
@@ -29,6 +29,7 @@
   "parameter-station-mapping.load.error": "Missing value for 'parameter-station-mapping.load.error'",
   "map.load.error": "Missing value for 'map.load.error'",
   "map.not-initialized.error": "Missing value for 'map.not-initialized.error'",
+  "collection.load.error": "Missing value for 'collection.load.error'",
   "asset.load.error": "Missing value for 'asset.load.error'",
   "asset.parse.error": "Errore durante l'analisi del file '{{filename}}'."
 }

--- a/src/app/shared/errors/collection.error.ts
+++ b/src/app/shared/errors/collection.error.ts
@@ -1,0 +1,6 @@
+import {marker} from '@jsverse/transloco-keys-manager/marker';
+import {FatalError} from './base.error';
+
+export class CollectionError extends FatalError {
+  public override message = marker('collection.load.error');
+}

--- a/src/app/shared/errors/stac.error.ts
+++ b/src/app/shared/errors/stac.error.ts
@@ -1,0 +1,15 @@
+import {marker} from '@jsverse/transloco-keys-manager/marker';
+import {FatalError} from './base.error';
+
+export class StacLoadError extends FatalError {
+  public override message = marker('stac.load.error');
+  public override translationArguments: Record<'collectionId' | 'stationId', string>;
+
+  constructor(collectionId: string, stationId?: string, originalError?: unknown) {
+    super(originalError);
+    this.translationArguments = {
+      collectionId: collectionId,
+      stationId: stationId ?? '<null>',
+    };
+  }
+}

--- a/src/app/shared/models/collection-assets.ts
+++ b/src/app/shared/models/collection-assets.ts
@@ -1,0 +1,6 @@
+export interface CollectionAsset {
+  metaFileType: 'station' | 'parameter' | 'data-inventory' | undefined;
+  filename: string;
+  url: string;
+  collection: string;
+}

--- a/src/app/stac/models/stac-asset.ts
+++ b/src/app/stac/models/stac-asset.ts
@@ -1,4 +1,4 @@
-export interface StacStationAsset {
+export interface StacAsset {
   filename: string;
   url: string | undefined;
 }

--- a/src/app/stac/service/asset.service.spec.ts
+++ b/src/app/stac/service/asset.service.spec.ts
@@ -9,7 +9,7 @@ describe('AssetService', () => {
   let stacApiService: jasmine.SpyObj<StacApiService>;
 
   beforeEach(() => {
-    stacApiService = jasmine.createSpyObj<StacApiService>('StacApiService', ['getStationAssets']);
+    stacApiService = jasmine.createSpyObj<StacApiService>('StacApiService', ['getAssets']);
     const errorHandler = jasmine.createSpyObj<ErrorHandler>('ErrorHandler', ['handleError']);
     errorHandler.handleError.and.callFake((error) => {
       throw error;
@@ -29,87 +29,123 @@ describe('AssetService', () => {
     service = TestBed.inject(AssetService);
   });
 
-  it('should get the assets for a station form the stacApiService and parse the filename', async () => {
-    const collection = 'collection';
-    const stationId = 'stationId';
-    stacApiService.getStationAssets.and.resolveTo([
-      {filename: `${collection}_${stationId}_t_now.csv`, url: 'www.meteoschweiz.admin.ch'},
-      {filename: `${collection}_${stationId}_m_recent.csv`, url: 'www.meteoschweiz.admin.ch'},
-      {filename: `${collection}_${stationId}_h_recent.csv`, url: 'www.meteoschweiz.admin.ch'},
-      {filename: `${collection}_${stationId}_d_recent.csv`, url: 'www.meteoschweiz.admin.ch'},
-      {filename: `${collection}_${stationId}_y_historical.csv`, url: 'www.meteoschweiz.admin.ch'},
-    ]);
+  describe('loadCollectionAssets', () => {
+    it('should get the collection assets from the stac API and transform the result', async () => {
+      const collection = ['collection'];
+      stacApiService.getAssets.and.resolveTo([
+        {filename: `${collection}_datainventory.csv`, url: 'www.meteoschweiz.admin.ch'},
+        {filename: `${collection}_parameters.csv`, url: 'www.meteoschweiz.admin.ch'},
+        {filename: `${collection}_stations.csv`, url: 'www.meteoschweiz.admin.ch'},
+      ]);
 
-    const result = await service.loadStationAssets(collection, stationId);
+      const result = await service.loadCollectionAssets(collection);
 
-    expect(result).toEqual([
-      {filename: `${collection}_${stationId}_t_now.csv`, url: 'www.meteoschweiz.admin.ch', interval: 'ten-minutes', timeRange: 'now'},
-      {filename: `${collection}_${stationId}_m_recent.csv`, url: 'www.meteoschweiz.admin.ch', interval: 'monthly', timeRange: 'recent'},
-      {filename: `${collection}_${stationId}_h_recent.csv`, url: 'www.meteoschweiz.admin.ch', interval: 'hourly', timeRange: 'recent'},
-      {filename: `${collection}_${stationId}_d_recent.csv`, url: 'www.meteoschweiz.admin.ch', interval: 'daily', timeRange: 'recent'},
-      {
-        filename: `${collection}_${stationId}_y_historical.csv`,
-        url: 'www.meteoschweiz.admin.ch',
-        interval: 'yearly',
-        timeRange: 'historical',
-        dateRange: undefined,
-      },
-    ] satisfies StationAsset[]);
+      expect(result).toEqual([
+        {
+          filename: `${collection}_datainventory.csv`,
+          url: 'www.meteoschweiz.admin.ch',
+          metaFileType: 'data-inventory',
+          collection: 'collection',
+        },
+        {
+          filename: `${collection}_parameters.csv`,
+          url: 'www.meteoschweiz.admin.ch',
+          metaFileType: 'parameter',
+          collection: 'collection',
+        },
+        {
+          filename: `${collection}_stations.csv`,
+          url: 'www.meteoschweiz.admin.ch',
+          metaFileType: 'station',
+          collection: 'collection',
+        },
+      ]);
+    });
   });
 
-  it('should parse assets with explicit time range', async () => {
-    const collection = 'collection';
-    const stationId = 'stationId';
-    stacApiService.getStationAssets.and.resolveTo([
-      {filename: `${collection}_${stationId}_t_historical_19910101_20001231.csv`, url: 'www.meteoschweiz.admin.ch'},
-      {filename: `${collection}_${stationId}_t_historical_20010101_20101231.csv`, url: 'www.meteoschweiz.admin.ch'},
-      {filename: `${collection}_${stationId}_t_historical_20110101_20201231.csv`, url: 'www.meteoschweiz.admin.ch'},
-    ]);
+  describe('loadStationAssets', () => {
+    it('should get the assets for a station form the stacApiService and parse the filename', async () => {
+      const collection = 'collection';
+      const stationId = 'stationId';
+      stacApiService.getAssets.and.resolveTo([
+        {filename: `${collection}_${stationId}_t_now.csv`, url: 'www.meteoschweiz.admin.ch'},
+        {filename: `${collection}_${stationId}_m_recent.csv`, url: 'www.meteoschweiz.admin.ch'},
+        {filename: `${collection}_${stationId}_h_recent.csv`, url: 'www.meteoschweiz.admin.ch'},
+        {filename: `${collection}_${stationId}_d_recent.csv`, url: 'www.meteoschweiz.admin.ch'},
+        {filename: `${collection}_${stationId}_y_historical.csv`, url: 'www.meteoschweiz.admin.ch'},
+      ]);
 
-    const result = await service.loadStationAssets(collection, stationId);
+      const result = await service.loadStationAssets(collection, stationId);
 
-    expect(result).toEqual(
-      jasmine.arrayWithExactContents([
+      expect(result).toEqual([
+        {filename: `${collection}_${stationId}_t_now.csv`, url: 'www.meteoschweiz.admin.ch', interval: 'ten-minutes', timeRange: 'now'},
+        {filename: `${collection}_${stationId}_m_recent.csv`, url: 'www.meteoschweiz.admin.ch', interval: 'monthly', timeRange: 'recent'},
+        {filename: `${collection}_${stationId}_h_recent.csv`, url: 'www.meteoschweiz.admin.ch', interval: 'hourly', timeRange: 'recent'},
+        {filename: `${collection}_${stationId}_d_recent.csv`, url: 'www.meteoschweiz.admin.ch', interval: 'daily', timeRange: 'recent'},
         {
-          filename: `${collection}_${stationId}_t_historical_19910101_20001231.csv`,
+          filename: `${collection}_${stationId}_y_historical.csv`,
           url: 'www.meteoschweiz.admin.ch',
-          interval: 'ten-minutes',
+          interval: 'yearly',
           timeRange: 'historical',
-          dateRange: {start: jasmine.any(Date), end: jasmine.any(Date)},
+          dateRange: undefined,
         },
-        {
-          filename: `${collection}_${stationId}_t_historical_20010101_20101231.csv`,
-          url: 'www.meteoschweiz.admin.ch',
-          interval: 'ten-minutes',
-          timeRange: 'historical',
-          dateRange: {start: jasmine.any(Date), end: jasmine.any(Date)},
-        },
-        {
-          filename: `${collection}_${stationId}_t_historical_20110101_20201231.csv`,
-          url: 'www.meteoschweiz.admin.ch',
-          interval: 'ten-minutes',
-          timeRange: 'historical',
-          dateRange: {start: jasmine.any(Date), end: jasmine.any(Date)},
-        },
-      ]),
-    );
-  });
+      ] satisfies StationAsset[]);
+    });
 
-  it('should parse dates correctly', async () => {
-    const collection = 'collection';
-    const stationId = 'stationId';
-    stacApiService.getStationAssets.and.resolveTo([
-      {filename: `${collection}_${stationId}_t_historical_19910101_20001231.csv`, url: 'www.meteoschweiz.admin.ch'},
-    ]);
+    it('should parse assets with explicit time range', async () => {
+      const collection = 'collection';
+      const stationId = 'stationId';
+      stacApiService.getAssets.and.resolveTo([
+        {filename: `${collection}_${stationId}_t_historical_19910101_20001231.csv`, url: 'www.meteoschweiz.admin.ch'},
+        {filename: `${collection}_${stationId}_t_historical_20010101_20101231.csv`, url: 'www.meteoschweiz.admin.ch'},
+        {filename: `${collection}_${stationId}_t_historical_20110101_20201231.csv`, url: 'www.meteoschweiz.admin.ch'},
+      ]);
 
-    const result = await service.loadStationAssets(collection, stationId);
+      const result = await service.loadStationAssets(collection, stationId);
 
-    expect(result).toEqual(
-      jasmine.arrayWithExactContents([
-        jasmine.objectContaining({
-          dateRange: {start: new Date('1991-01-01T00:00'), end: new Date('2000-12-31T00:00')},
-        }),
-      ]),
-    );
+      expect(result).toEqual(
+        jasmine.arrayWithExactContents([
+          {
+            filename: `${collection}_${stationId}_t_historical_19910101_20001231.csv`,
+            url: 'www.meteoschweiz.admin.ch',
+            interval: 'ten-minutes',
+            timeRange: 'historical',
+            dateRange: {start: jasmine.any(Date), end: jasmine.any(Date)},
+          },
+          {
+            filename: `${collection}_${stationId}_t_historical_20010101_20101231.csv`,
+            url: 'www.meteoschweiz.admin.ch',
+            interval: 'ten-minutes',
+            timeRange: 'historical',
+            dateRange: {start: jasmine.any(Date), end: jasmine.any(Date)},
+          },
+          {
+            filename: `${collection}_${stationId}_t_historical_20110101_20201231.csv`,
+            url: 'www.meteoschweiz.admin.ch',
+            interval: 'ten-minutes',
+            timeRange: 'historical',
+            dateRange: {start: jasmine.any(Date), end: jasmine.any(Date)},
+          },
+        ]),
+      );
+    });
+
+    it('should parse dates correctly', async () => {
+      const collection = 'collection';
+      const stationId = 'stationId';
+      stacApiService.getAssets.and.resolveTo([
+        {filename: `${collection}_${stationId}_t_historical_19910101_20001231.csv`, url: 'www.meteoschweiz.admin.ch'},
+      ]);
+
+      const result = await service.loadStationAssets(collection, stationId);
+
+      expect(result).toEqual(
+        jasmine.arrayWithExactContents([
+          jasmine.objectContaining({
+            dateRange: {start: new Date('1991-01-01T00:00'), end: new Date('2000-12-31T00:00')},
+          }),
+        ]),
+      );
+    });
   });
 });

--- a/src/app/stac/service/asset.service.ts
+++ b/src/app/stac/service/asset.service.ts
@@ -48,13 +48,14 @@ export class AssetService {
     if (!asset.url) {
       throw new AssetParseError(asset.filename);
     }
-    const metaFileType = asset.filename.includes('station')
-      ? 'station'
-      : asset.filename.includes('parameter')
-        ? 'parameter'
-        : asset.filename.includes('datainventory')
-          ? 'data-inventory'
-          : undefined;
+    let metaFileType: CollectionAsset['metaFileType'] = undefined;
+    if (asset.filename.includes('station')) {
+      metaFileType = 'station';
+    } else if (asset.filename.includes('parameter')) {
+      metaFileType = 'parameter';
+    } else if (asset.filename.includes('datainventory')) {
+      metaFileType = 'data-inventory';
+    }
 
     return {
       metaFileType,

--- a/src/app/stac/service/asset.service.ts
+++ b/src/app/stac/service/asset.service.ts
@@ -2,10 +2,11 @@ import {ErrorHandler, inject, Injectable} from '@angular/core';
 import {AssetParseError} from '../../shared/errors/asset.error';
 import {isTimeRange} from '../../shared/type-guards/time-range-guard';
 import {StacApiService} from './stac-api.service';
+import type {CollectionAsset} from '../../shared/models/collection-assets';
 import type {DataInterval} from '../../shared/models/interval';
 import type {StationAsset} from '../../shared/models/station-assets';
 import type {TimeRange} from '../../shared/models/time-range';
-import type {StacStationAsset} from '../models/stac-station-asset';
+import type {StacAsset} from '../models/stac-asset';
 
 @Injectable({
   providedIn: 'root',
@@ -14,11 +15,20 @@ export class AssetService {
   private readonly stacApiService = inject(StacApiService);
   private readonly errorHandler = inject(ErrorHandler);
 
-  private readonly parseRegex =
+  private readonly stationParseRegex =
     /^(?<collectionId>[^_]+)_(?<stationId>[^_]+)_(?<interval>[^_]+)_(?<timeRange>[^_]+)(?:_(?<fromDate>\d{8})_(?<toDate>\d{8}))?\.csv$/;
 
+  public async loadCollectionAssets(collections: string[]): Promise<CollectionAsset[]> {
+    const assets = await Promise.all(
+      collections.map(async (collection) =>
+        (await this.stacApiService.getAssets(collection)).map((asset) => this.transformStacCollectionAsset(collection, asset)),
+      ),
+    );
+    return assets.flat();
+  }
+
   public async loadStationAssets(collection: string, stationId: string): Promise<StationAsset[]> {
-    const assets = await this.stacApiService.getStationAssets(collection, stationId);
+    const assets = await this.stacApiService.getAssets(collection, stationId);
     return assets
       .map((asset) => {
         try {
@@ -34,12 +44,32 @@ export class AssetService {
       .filter((asset) => asset != null);
   }
 
-  private parseStacStationAsset(asset: StacStationAsset): StationAsset {
+  private transformStacCollectionAsset(collection: string, asset: StacAsset): CollectionAsset {
+    if (!asset.url) {
+      throw new AssetParseError(asset.filename);
+    }
+    const metaFileType = asset.filename.includes('station')
+      ? 'station'
+      : asset.filename.includes('parameter')
+        ? 'parameter'
+        : asset.filename.includes('datainventory')
+          ? 'data-inventory'
+          : undefined;
+
+    return {
+      metaFileType,
+      filename: asset.filename,
+      url: asset.url,
+      collection: collection,
+    };
+  }
+
+  private parseStacStationAsset(asset: StacAsset): StationAsset {
     if (!asset.url) {
       throw new AssetParseError(asset.filename);
     }
 
-    const matches = RegExp(this.parseRegex).exec(asset.filename);
+    const matches = RegExp(this.stationParseRegex).exec(asset.filename);
     if (!matches || !matches.groups) {
       throw new AssetParseError(asset.filename);
     }

--- a/src/app/stac/service/data-inventory.service.spec.ts
+++ b/src/app/stac/service/data-inventory.service.spec.ts
@@ -76,7 +76,7 @@ describe('DataInventoryService', () => {
   it('should only load assets of meta type data-inventory', async () => {
     stacApiService.fetchAndParseCsvFile.and.resolveTo([testCsvDataInventory]);
 
-    const _ = await service.loadParameterStationMappingsForCollections(testCollectionAssets);
+    await service.loadParameterStationMappingsForCollections(testCollectionAssets);
 
     expect(stacApiService.fetchAndParseCsvFile).toHaveBeenCalledOnceWith('data-inventory://');
   });

--- a/src/app/stac/service/data-inventory.service.ts
+++ b/src/app/stac/service/data-inventory.service.ts
@@ -1,4 +1,5 @@
 import {inject, Injectable} from '@angular/core';
+import {CollectionAsset} from '../../shared/models/collection-assets';
 import {ParameterStationMapping} from '../../shared/models/parameter-station-mapping';
 import {CsvDataInventory} from '../models/csv-data-inventory';
 import {ParameterService} from './parameter.service';
@@ -10,19 +11,15 @@ import {StacApiService} from './stac-api.service';
 export class DataInventoryService {
   private readonly stacApiService = inject(StacApiService);
 
-  public async loadParameterStationMappingsForCollections(collections: string[]): Promise<ParameterStationMapping[]> {
-    const parameterStationMappings = await Promise.all(
-      collections.map((collection) => this.getParameterStationMappingsForCollection(collection)),
-    );
+  public async loadParameterStationMappingsForCollections(collectionAssets: CollectionAsset[]): Promise<ParameterStationMapping[]> {
+    const relevantAssets = collectionAssets.filter((asset) => asset.metaFileType === 'data-inventory');
+    const parameterStationMappings = await Promise.all(relevantAssets.map((asset) => this.getParameterStationMappingsForCollection(asset)));
     return parameterStationMappings.flat();
   }
 
-  private async getParameterStationMappingsForCollection(collection: string): Promise<ParameterStationMapping[]> {
-    const csvDataInventory: CsvDataInventory[] = await this.stacApiService.getCollectionMetaCsvFile<CsvDataInventory>(
-      collection,
-      'datainventory',
-    );
-    return csvDataInventory.map((dataInventory) => this.transformCsvDataInventory(dataInventory, collection));
+  private async getParameterStationMappingsForCollection(collectionAsset: CollectionAsset): Promise<ParameterStationMapping[]> {
+    const csvDataInventory: CsvDataInventory[] = await this.stacApiService.fetchAndParseCsvFile<CsvDataInventory>(collectionAsset.url);
+    return csvDataInventory.map((dataInventory) => this.transformCsvDataInventory(dataInventory, collectionAsset.collection));
   }
 
   private transformCsvDataInventory(csvDataInventory: CsvDataInventory, collection: string): ParameterStationMapping {

--- a/src/app/stac/service/data-inventory.service.ts
+++ b/src/app/stac/service/data-inventory.service.ts
@@ -18,7 +18,7 @@ export class DataInventoryService {
   }
 
   private async getParameterStationMappingsForCollection(collectionAsset: CollectionAsset): Promise<ParameterStationMapping[]> {
-    const csvDataInventory: CsvDataInventory[] = await this.stacApiService.fetchAndParseCsvFile<CsvDataInventory>(collectionAsset.url);
+    const csvDataInventory = await this.stacApiService.fetchAndParseCsvFile<CsvDataInventory>(collectionAsset.url);
     return csvDataInventory.map((dataInventory) => this.transformCsvDataInventory(dataInventory, collectionAsset.collection));
   }
 

--- a/src/app/stac/service/parameter.service.spec.ts
+++ b/src/app/stac/service/parameter.service.spec.ts
@@ -90,7 +90,7 @@ describe('ParameterService', () => {
     it('should only load assets of meta type parameter', async () => {
       stacApiService.fetchAndParseCsvFile.and.resolveTo([testCsvParameter]);
 
-      const _ = await service.loadParameterForCollections(testCollectionAssets);
+      await service.loadParameterForCollections(testCollectionAssets);
 
       expect(stacApiService.fetchAndParseCsvFile).toHaveBeenCalledOnceWith('parameter://');
     });

--- a/src/app/stac/service/parameter.service.ts
+++ b/src/app/stac/service/parameter.service.ts
@@ -32,7 +32,7 @@ export class ParameterService {
   }
 
   private async getParametersForCollection(collectionAsset: CollectionAsset): Promise<Parameter[]> {
-    const csvParameters: CsvParameter[] = await this.stacApiService.fetchAndParseCsvFile<CsvParameter>(collectionAsset.url);
+    const csvParameters = await this.stacApiService.fetchAndParseCsvFile<CsvParameter>(collectionAsset.url);
     return csvParameters.map((csvParameter) => this.transformCsvParameter(csvParameter));
   }
 

--- a/src/app/stac/service/stac-api.service.ts
+++ b/src/app/stac/service/stac-api.service.ts
@@ -10,28 +10,9 @@ import {StacAsset} from '../models/stac-asset';
 export class StacApiService {
   private readonly stacApiClient = new StacApiClient({baseUrl: defaultStacClientConfig.baseUrl});
 
-  public async getCollectionMetaCsvFile<T>(collectionName: string, metaFile: 'stations' | 'parameters' | 'datainventory'): Promise<T[]> {
-    const collectionResponse = await this.stacApiClient.collections.describeCollection(collectionName, {format: 'json'});
-    if (!collectionResponse.ok) {
-      // TODO: create specific error classes
-      throw new Error(`Failed to get collection ${collectionName}`);
-    }
-
-    const collection = collectionResponse.data;
-    if (collection == null) {
-      throw new Error(`Collection was null. Collection: ${collectionName}, metaFile: ${metaFile}`);
-    }
-    if (collection.assets == null) {
-      throw new Error(`Collection did not contain any assets. Collection: ${collectionName}, metaFile: ${metaFile}`);
-    }
-
-    const metaDataFileUrl = Object.entries(collection.assets).find(([key]) => key.includes(metaFile))?.[1]?.href;
-    if (!metaDataFileUrl) {
-      throw new Error(`Could not find URL for meta data CSV. Collection: ${collectionName}, metaFile: ${metaFile}`);
-    }
-
-    const parsedResult = new Promise<T[]>((resolve) => {
-      papa.parse<T>(metaDataFileUrl, {
+  public fetchAndParseCsvFile<T>(url: string): Promise<T[]> {
+    return new Promise<T[]>((resolve) => {
+      papa.parse<T>(url, {
         download: true,
         delimiter: defaultStacClientConfig.csvDelimiter,
         header: true,
@@ -48,7 +29,6 @@ export class StacApiService {
         },
       });
     });
-    return parsedResult;
   }
 
   public async getAssets(collectionId: string, stationId?: string): Promise<StacAsset[]> {
@@ -56,6 +36,7 @@ export class StacApiService {
       stationId != null
         ? await this.stacApiClient.collections.getFeature(collectionId, stationId.toLocaleLowerCase(), {format: 'json'})
         : await this.stacApiClient.collections.describeCollection(collectionId, {format: 'json'});
+
     if (!response.ok) {
       throw new Error(`Failed to get Assets for collectionId '${collectionId}', stationId '${stationId}'`);
     }

--- a/src/app/stac/service/stac-api.service.ts
+++ b/src/app/stac/service/stac-api.service.ts
@@ -1,6 +1,7 @@
 import {Injectable} from '@angular/core';
 import papa from 'papaparse';
 import {defaultStacClientConfig} from '../../shared/configs/stac.config';
+import {StacLoadError} from '../../shared/errors/stac.error';
 import {StacApiClient} from '../generated/stac-api.generated';
 import {StacAsset} from '../models/stac-asset';
 
@@ -38,17 +39,17 @@ export class StacApiService {
         : await this.stacApiClient.collections.describeCollection(collectionId, {format: 'json'});
 
     if (!response.ok) {
-      throw new Error(`Failed to get Assets for collectionId '${collectionId}', stationId '${stationId}'`);
+      throw new StacLoadError(collectionId, stationId);
     }
 
     const feature = response.data;
     if (feature == null) {
-      throw new Error(`Response data was 'null' for collectionId '${collectionId}', stationId '${stationId}'`);
+      throw new StacLoadError(collectionId, stationId);
     }
 
     const assets = feature.assets;
     if (assets == null) {
-      throw new Error(`Asset data was undefined for collectionId '${collectionId}', stationId '${stationId}'`);
+      throw new StacLoadError(collectionId, stationId);
     }
 
     return Object.entries(assets)

--- a/src/app/stac/service/station.service.spec.ts
+++ b/src/app/stac/service/station.service.spec.ts
@@ -103,7 +103,7 @@ describe('StationService', () => {
   it('should only load assets of meta type station', async () => {
     stacApiService.fetchAndParseCsvFile.and.resolveTo([testCsvStation]);
 
-    const _ = await service.loadStationsForCollections(testCollectionAssets);
+    await service.loadStationsForCollections(testCollectionAssets);
 
     expect(stacApiService.fetchAndParseCsvFile).toHaveBeenCalledOnceWith('station://');
   });

--- a/src/app/stac/service/station.service.ts
+++ b/src/app/stac/service/station.service.ts
@@ -17,7 +17,7 @@ export class StationService {
   }
 
   private async getStationForCollection(collectionAsset: CollectionAsset): Promise<Station[]> {
-    const csvStations: CsvStation[] = await this.stacApiService.fetchAndParseCsvFile<CsvStation>(collectionAsset.url);
+    const csvStations = await this.stacApiService.fetchAndParseCsvFile<CsvStation>(collectionAsset.url);
     return csvStations.map((csvStation) => this.transformCsvStation(csvStation, collectionAsset.collection));
   }
 

--- a/src/app/state/collection/actions/collection.action.ts
+++ b/src/app/state/collection/actions/collection.action.ts
@@ -1,9 +1,12 @@
 import {createActionGroup, props} from '@ngrx/store';
-import {MeasurementDataType} from '../../../shared/models/measurement-data-type';
+import type {CollectionAsset} from '../../../shared/models/collection-assets';
+import type {MeasurementDataType} from '../../../shared/models/measurement-data-type';
 
 export const collectionActions = createActionGroup({
   source: 'Collections',
   events: {
     'Load collections': props<{collections: string[]; measurementDataType: MeasurementDataType}>(),
+    'Set collection assets': props<{assets: CollectionAsset[]; measurementDataType: MeasurementDataType}>(),
+    'Set collection asset loading error': props<{error?: unknown; measurementDataType: MeasurementDataType}>(),
   },
 });

--- a/src/app/state/collection/effects/collection.effects.spec.ts
+++ b/src/app/state/collection/effects/collection.effects.spec.ts
@@ -67,7 +67,7 @@ describe('Collection Effects', () => {
     });
   });
 
-  it('should throw a Station error after dispatching setCollectionAssetLoadingError', (done: DoneFn) => {
+  it('should throw a collection error after dispatching setCollectionAssetLoadingError', (done: DoneFn) => {
     const error = new Error('My cabbages!!!');
     const expectedError = new CollectionError(error);
 

--- a/src/app/state/collection/effects/collection.effects.spec.ts
+++ b/src/app/state/collection/effects/collection.effects.spec.ts
@@ -1,0 +1,85 @@
+import {TestBed} from '@angular/core/testing';
+import {Action} from '@ngrx/store';
+import {MockStore, provideMockStore} from '@ngrx/store/testing';
+import {catchError, EMPTY, Observable, of} from 'rxjs';
+import {collectionConfig} from '../../../shared/configs/collections.config';
+import {CollectionError} from '../../../shared/errors/collection.error';
+import {OpendataExplorerRuntimeErrorTestUtil} from '../../../shared/testing/utils/opendata-explorer-runtime-error-test.util';
+import {AssetService} from '../../../stac/service/asset.service';
+import {collectionActions} from '../actions/collection.action';
+import {selectCurrentCollectionState} from '../selectors/collection.selector';
+import {failLoadingCollectionAssets, loadCollectionAssets} from './collection.effects';
+
+describe('Collection Effects', () => {
+  const measurementDataType = collectionConfig.defaultMeasurementDataType;
+
+  let actions$: Observable<Action>;
+  let store: MockStore;
+  let assetService: AssetService;
+
+  beforeEach(() => {
+    actions$ = new Observable<Action>();
+    TestBed.configureTestingModule({
+      providers: [provideMockStore()],
+    });
+    store = TestBed.inject(MockStore);
+    assetService = TestBed.inject(AssetService);
+  });
+
+  afterEach(() => {
+    store.resetSelectors();
+  });
+
+  it('should dispatch the setCollectionAssets action when loading collections', (done: DoneFn) => {
+    spyOn(assetService, 'loadCollectionAssets').and.resolveTo([]);
+    const collections = ['collection'];
+    store.overrideSelector(selectCurrentCollectionState, {collectionAssets: [], loadingState: undefined});
+    actions$ = of(collectionActions.loadCollections({collections, measurementDataType}));
+
+    loadCollectionAssets(actions$, store, assetService).subscribe((action) => {
+      expect(action).toEqual(collectionActions.setCollectionAssets({assets: [], measurementDataType}));
+      done();
+    });
+  });
+
+  it('should not call the service if the data is already loaded', (done: DoneFn) => {
+    spyOn(assetService, 'loadCollectionAssets');
+    store.overrideSelector(selectCurrentCollectionState, {collectionAssets: [], loadingState: 'loaded'});
+    actions$ = of(collectionActions.loadCollections({collections: ['collection'], measurementDataType}));
+
+    loadCollectionAssets(actions$, store, assetService).subscribe({
+      complete: () => {
+        expect(assetService.loadCollectionAssets).not.toHaveBeenCalled();
+        done();
+      },
+    });
+  });
+
+  it('should set loading error if the service throws an error', (done: DoneFn) => {
+    const error = new Error('test');
+    spyOn(assetService, 'loadCollectionAssets').and.rejectWith(error);
+    store.overrideSelector(selectCurrentCollectionState, {collectionAssets: [], loadingState: undefined});
+    actions$ = of(collectionActions.loadCollections({collections: ['collection'], measurementDataType}));
+
+    loadCollectionAssets(actions$, store, assetService).subscribe((action) => {
+      expect(action).toEqual(collectionActions.setCollectionAssetLoadingError({error, measurementDataType}));
+      done();
+    });
+  });
+
+  it('should throw a Station error after dispatching setCollectionAssetLoadingError', (done: DoneFn) => {
+    const error = new Error('My cabbages!!!');
+    const expectedError = new CollectionError(error);
+
+    actions$ = of(collectionActions.setCollectionAssetLoadingError({error, measurementDataType}));
+    failLoadingCollectionAssets(actions$)
+      .pipe(
+        catchError((caughtError: unknown) => {
+          OpendataExplorerRuntimeErrorTestUtil.expectToDeepEqual(caughtError, expectedError);
+          done();
+          return EMPTY;
+        }),
+      )
+      .subscribe();
+  });
+});

--- a/src/app/state/collection/effects/collection.effects.ts
+++ b/src/app/state/collection/effects/collection.effects.ts
@@ -1,0 +1,38 @@
+import {inject} from '@angular/core';
+import {Actions, createEffect, ofType} from '@ngrx/effects';
+import {concatLatestFrom} from '@ngrx/operators';
+import {Store} from '@ngrx/store';
+import {catchError, filter, from, map, of, switchMap, tap} from 'rxjs';
+import {CollectionError} from '../../../shared/errors/collection.error';
+import {AssetService} from '../../../stac/service/asset.service';
+import {collectionActions} from '../actions/collection.action';
+import {selectCurrentCollectionState} from '../selectors/collection.selector';
+
+export const loadCollectionAssets = createEffect(
+  (actions$ = inject(Actions), store = inject(Store), assetService = inject(AssetService)) => {
+    return actions$.pipe(
+      ofType(collectionActions.loadCollections),
+      concatLatestFrom(() => store.select(selectCurrentCollectionState)),
+      filter(([_, stationState]) => stationState.loadingState !== 'loaded'),
+      switchMap(([{collections, measurementDataType}]) =>
+        from(assetService.loadCollectionAssets(collections)).pipe(
+          map((assets) => collectionActions.setCollectionAssets({assets, measurementDataType})),
+          catchError((error: unknown) => of(collectionActions.setCollectionAssetLoadingError({error, measurementDataType}))),
+        ),
+      ),
+    );
+  },
+  {functional: true},
+);
+
+export const failLoadingCollectionAssets = createEffect(
+  (actions$ = inject(Actions)) => {
+    return actions$.pipe(
+      ofType(collectionActions.setCollectionAssetLoadingError),
+      tap(({error}) => {
+        throw new CollectionError(error);
+      }),
+    );
+  },
+  {functional: true, dispatch: false},
+);

--- a/src/app/state/collection/effects/collection.effects.ts
+++ b/src/app/state/collection/effects/collection.effects.ts
@@ -13,7 +13,7 @@ export const loadCollectionAssets = createEffect(
     return actions$.pipe(
       ofType(collectionActions.loadCollections),
       concatLatestFrom(() => store.select(selectCurrentCollectionState)),
-      filter(([_, stationState]) => stationState.loadingState !== 'loaded'),
+      filter(([_, collectionState]) => collectionState.loadingState !== 'loaded'),
       switchMap(([{collections, measurementDataType}]) =>
         from(assetService.loadCollectionAssets(collections)).pipe(
           map((assets) => collectionActions.setCollectionAssets({assets, measurementDataType})),

--- a/src/app/state/collection/reducers/collection.reducer.spec.ts
+++ b/src/app/state/collection/reducers/collection.reducer.spec.ts
@@ -1,0 +1,63 @@
+import {collectionConfig} from '../../../shared/configs/collections.config';
+import {CollectionAsset} from '../../../shared/models/collection-assets';
+import {collectionActions} from '../actions/collection.action';
+import {CollectionState} from '../states/collection.state';
+import {collectionFeature, initialState} from './collection.reducer';
+
+describe('Collection Reducer', () => {
+  const measurementDataType = collectionConfig.defaultMeasurementDataType;
+
+  let state: CollectionState;
+
+  beforeEach(() => {
+    state = structuredClone(initialState);
+  });
+
+  it('should set loadingState to loading when loadCollection is dispatched and loading state is currently not loaded', () => {
+    state[measurementDataType].loadingState = 'error';
+    const action = collectionActions.loadCollections({collections: ['test'], measurementDataType});
+
+    const result = collectionFeature.reducer(state, action);
+
+    expect(result[measurementDataType].loadingState).toBe('loading');
+    expect(result[measurementDataType].collectionAssets).toEqual([]);
+  });
+
+  it('should not change loadingState if it is already loaded when loadCollection is dispatched', () => {
+    state[measurementDataType].loadingState = 'loaded';
+    const action = collectionActions.loadCollections({collections: ['test'], measurementDataType});
+
+    const result = collectionFeature.reducer(state, action);
+
+    expect(result[measurementDataType].loadingState).toBe('loaded');
+    expect(result[measurementDataType].collectionAssets).toEqual([]);
+  });
+
+  it('should set collection assets and loadingState to loaded when setCollectionAssets is dispatched', () => {
+    const assets: CollectionAsset[] = [
+      {
+        collection: 'collection',
+        filename: 'meta.csv',
+        metaFileType: 'station',
+        url: '',
+      },
+    ];
+    const action = collectionActions.setCollectionAssets({assets, measurementDataType});
+
+    const result = collectionFeature.reducer(state, action);
+
+    expect(result[measurementDataType].loadingState).toBe('loaded');
+    expect(result[measurementDataType].collectionAssets).toEqual(assets);
+  });
+
+  it('should reset to initialState and set loadingState to error when setCollectionAssetLoadingError is dispatched', () => {
+    const action = collectionActions.setCollectionAssetLoadingError({measurementDataType});
+
+    const result = collectionFeature.reducer(state, action);
+
+    expect(result).toEqual({
+      ...initialState,
+      [measurementDataType]: {...initialState[measurementDataType], loadingState: 'error'},
+    });
+  });
+});

--- a/src/app/state/collection/reducers/collection.reducer.ts
+++ b/src/app/state/collection/reducers/collection.reducer.ts
@@ -1,0 +1,43 @@
+import {createFeature, createReducer, on} from '@ngrx/store';
+import {produce} from 'immer';
+import {collectionActions} from '../actions/collection.action';
+import {CollectionState, CollectionStateEntry} from '../states/collection.state';
+
+export const collectionFeatureKey = 'collection';
+
+export const initialEntryState: CollectionStateEntry = {
+  loadingState: undefined,
+  collectionAssets: [],
+};
+export const initialState: CollectionState = {
+  homogenous: {...initialEntryState},
+  normal: {...initialEntryState},
+};
+
+export const collectionFeature = createFeature({
+  name: collectionFeatureKey,
+  reducer: createReducer(
+    initialState,
+    on(
+      collectionActions.loadCollections,
+      produce((draft, {measurementDataType}) => {
+        const state = draft[measurementDataType];
+        state.loadingState = state.loadingState !== 'loaded' ? 'loading' : state.loadingState;
+      }),
+    ),
+    on(
+      collectionActions.setCollectionAssets,
+      produce((draft, {assets, measurementDataType}) => {
+        const state = draft[measurementDataType];
+        state.collectionAssets = assets;
+        state.loadingState = 'loaded';
+      }),
+    ),
+    on(
+      collectionActions.setCollectionAssetLoadingError,
+      produce((draft, {measurementDataType}) => {
+        draft[measurementDataType] = {...initialEntryState, loadingState: 'error'};
+      }),
+    ),
+  ),
+});

--- a/src/app/state/collection/selectors/collection.selector.spec.ts
+++ b/src/app/state/collection/selectors/collection.selector.spec.ts
@@ -1,8 +1,11 @@
+import {CollectionAsset} from '../../../shared/models/collection-assets';
 import {loadingStates} from '../../../shared/models/loading-state';
 import {ParameterStationMappingStateEntry} from '../../parameter-station-mapping/states/parameter-station-mapping.state';
 import {ParameterStateEntry} from '../../parameters/states/parameter.state';
 import {StationStateEntry} from '../../stations/states/station.state';
-import {selectCombinedLoadingState} from './collection.selector';
+import {initialState} from '../reducers/collection.reducer';
+import {CollectionState} from '../states/collection.state';
+import {selectCombinedLoadingState, selectCurrentCollectionState} from './collection.selector';
 
 describe('Collection Selectors', () => {
   describe('selectCombinedLoadingState', () => {
@@ -24,6 +27,31 @@ describe('Collection Selectors', () => {
 
       const result = selectCombinedLoadingState.projector(parameterState, stationState, mappingState);
       expect(result).toBe(undefined);
+    });
+  });
+
+  describe('selectCurrentCollectionState', () => {
+    let state: CollectionState;
+    beforeEach(() => {
+      state = structuredClone(initialState);
+    });
+    it('should return the current parameter state based on the selected measurement data type', () => {
+      const measurementDataType = 'normal';
+      const assets: CollectionAsset[] = [
+        {
+          collection: 'collection',
+          filename: 'meta.csv',
+          metaFileType: 'station',
+          url: '',
+        },
+      ];
+      state[measurementDataType].collectionAssets = assets;
+      state[measurementDataType].loadingState = 'loaded';
+
+      const result = selectCurrentCollectionState.projector(state, measurementDataType);
+
+      expect(result.collectionAssets).toEqual(jasmine.arrayWithExactContents(assets));
+      expect(result.loadingState).toBe('loaded');
     });
   });
 });

--- a/src/app/state/collection/selectors/collection.selector.ts
+++ b/src/app/state/collection/selectors/collection.selector.ts
@@ -1,8 +1,11 @@
 import {createSelector} from '@ngrx/store';
 import {LoadingState} from '../../../shared/models/loading-state';
+import {formFeature} from '../../form/reducers/form.reducer';
 import {selectCurrentParameterStationMappingState} from '../../parameter-station-mapping/selectors/parameter-group-station-mapping.selector';
 import {selectCurrentParameterState} from '../../parameters/selectors/parameter.selector';
 import {selectCurrentStationState} from '../../stations/selectors/station.selector';
+import {collectionFeature} from '../reducers/collection.reducer';
+import {CollectionStateEntry} from '../states/collection.state';
 
 /**
  * Selects the combined loading state of the current parameter, station and parameter-station-mapping state.
@@ -15,4 +18,10 @@ export const selectCombinedLoadingState = createSelector(
     // return the combined loading state when all loading states are identical; `undefined` otherwise
     return parameterLoadingState === stationLoadingState && stationLoadingState === mappingLoadingState ? parameterLoadingState : undefined;
   },
+);
+
+export const selectCurrentCollectionState = createSelector(
+  collectionFeature.selectCollectionState,
+  formFeature.selectSelectedMeasurementDataType,
+  (collectionState, measurementDataType): CollectionStateEntry => collectionState[measurementDataType],
 );

--- a/src/app/state/collection/states/collection.state.ts
+++ b/src/app/state/collection/states/collection.state.ts
@@ -1,0 +1,9 @@
+import type {CollectionAsset} from '../../../shared/models/collection-assets';
+import type {LoadableState} from '../../../shared/models/loadable-state';
+import type {MeasurementDataType} from '../../../shared/models/measurement-data-type';
+
+export interface CollectionStateEntry extends LoadableState {
+  collectionAssets: CollectionAsset[];
+}
+
+export type CollectionState = Record<MeasurementDataType, CollectionStateEntry>;

--- a/src/app/state/index.ts
+++ b/src/app/state/index.ts
@@ -6,6 +6,9 @@ import {AppState} from './app/states/app.state';
 import * as assertEffects from './assets/effects/asset.effects';
 import {assetFeature, assetFeatureKey} from './assets/reducers/asset.reducer';
 import {AssetState} from './assets/states/asset.state';
+import * as collectionEffects from './collection/effects/collection.effects';
+import {collectionFeature, collectionFeatureKey} from './collection/reducers/collection.reducer';
+import {CollectionState} from './collection/states/collection.state';
 import * as formEffects from './form/effects/form.effects';
 import {formFeature, formFeatureKey} from './form/reducers/form.reducer';
 import * as mapEffects from './map/effects/map.effects';
@@ -37,6 +40,7 @@ export interface State {
   [appFeatureKey]: AppState;
   router: RouterState;
   [assetFeatureKey]: AssetState;
+  [collectionFeatureKey]: CollectionState;
 }
 export const reducers: ActionReducerMap<State> = {
   [parameterFeatureKey]: parameterFeature.reducer,
@@ -47,6 +51,7 @@ export const reducers: ActionReducerMap<State> = {
   [appFeatureKey]: appFeature.reducer,
   router: routerReducer,
   [assetFeatureKey]: assetFeature.reducer,
+  [collectionFeatureKey]: collectionFeature.reducer,
 };
 export const effects: (Type<unknown> | Record<string, FunctionalEffect>)[] = [
   parameterEffects,
@@ -57,5 +62,6 @@ export const effects: (Type<unknown> | Record<string, FunctionalEffect>)[] = [
   appEffects,
   urlParameterEffects,
   assertEffects,
+  collectionEffects,
 ];
 export const metaReducers: MetaReducer<State>[] = [];

--- a/src/app/state/parameter-station-mapping/actions/parameter-station-mapping.action.ts
+++ b/src/app/state/parameter-station-mapping/actions/parameter-station-mapping.action.ts
@@ -1,4 +1,5 @@
 import {createActionGroup, props} from '@ngrx/store';
+import {CollectionAsset} from '../../../shared/models/collection-assets';
 import {MeasurementDataType} from '../../../shared/models/measurement-data-type';
 import {ParameterStationMapping} from '../../../shared/models/parameter-station-mapping';
 
@@ -9,7 +10,10 @@ export const parameterStationMappingActions = createActionGroup({
       parameterStationMappings: ParameterStationMapping[];
       measurementDataType: MeasurementDataType;
     }>(),
-    'Load parameter station mappings for collections': props<{collections: string[]; measurementDataType: MeasurementDataType}>(),
+    'Load parameter station mappings for collections': props<{
+      collectionAssets: CollectionAsset[];
+      measurementDataType: MeasurementDataType;
+    }>(),
     'Set parameter station mapping loading error': props<{error?: unknown; measurementDataType: MeasurementDataType}>(),
   },
 });

--- a/src/app/state/parameter-station-mapping/effects/parameter-station-mapping.effects.ts
+++ b/src/app/state/parameter-station-mapping/effects/parameter-station-mapping.effects.ts
@@ -12,9 +12,9 @@ import {selectCurrentParameterStationMappingState} from '../selectors/parameter-
 export const loadCollectionParameterStationMappings = createEffect(
   (actions$ = inject(Actions)) => {
     return actions$.pipe(
-      ofType(collectionActions.loadCollections),
-      map(({measurementDataType, collections}) =>
-        parameterStationMappingActions.loadParameterStationMappingsForCollections({collections, measurementDataType}),
+      ofType(collectionActions.setCollectionAssets),
+      map(({measurementDataType, assets}) =>
+        parameterStationMappingActions.loadParameterStationMappingsForCollections({collectionAssets: assets, measurementDataType}),
       ),
     );
   },
@@ -27,8 +27,8 @@ export const loadParameterStationMappings = createEffect(
       ofType(parameterStationMappingActions.loadParameterStationMappingsForCollections),
       concatLatestFrom(() => store.select(selectCurrentParameterStationMappingState)),
       filter(([_, parameterStationMappingState]) => parameterStationMappingState.loadingState !== 'loaded'),
-      switchMap(([{collections, measurementDataType}]) =>
-        from(dataInventoryService.loadParameterStationMappingsForCollections(collections)).pipe(
+      switchMap(([{collectionAssets, measurementDataType}]) =>
+        from(dataInventoryService.loadParameterStationMappingsForCollections(collectionAssets)).pipe(
           map((parameterStationMappings) =>
             parameterStationMappingActions.setLoadedParameterStationMappings({parameterStationMappings, measurementDataType}),
           ),

--- a/src/app/state/parameter-station-mapping/reducers/parameter-station-mapping.reducer.spec.ts
+++ b/src/app/state/parameter-station-mapping/reducers/parameter-station-mapping.reducer.spec.ts
@@ -1,4 +1,5 @@
 import {collectionConfig} from '../../../shared/configs/collections.config';
+import {CollectionAsset} from '../../../shared/models/collection-assets';
 import {ParameterStationMapping} from '../../../shared/models/parameter-station-mapping';
 import {parameterStationMappingActions} from '../actions/parameter-station-mapping.action';
 import {ParameterStationMappingState} from '../states/parameter-station-mapping.state';
@@ -6,6 +7,14 @@ import {initialState, parameterStationMappingFeature} from './parameter-station-
 
 describe('ParameterStationMapping Reducer', () => {
   const measurementDataType = collectionConfig.defaultMeasurementDataType;
+  const collectionAssets: CollectionAsset[] = [
+    {
+      filename: 'stations.csv',
+      metaFileType: 'station',
+      url: 'station://',
+      collection: 'test',
+    },
+  ];
 
   let state: ParameterStationMappingState;
 
@@ -15,7 +24,7 @@ describe('ParameterStationMapping Reducer', () => {
 
   it('should set loadingState to loading when loadParameterStationMappingForCollections is dispatched and loading state is currently not loaded', () => {
     state[measurementDataType].loadingState = 'error';
-    const action = parameterStationMappingActions.loadParameterStationMappingsForCollections({collections: ['test'], measurementDataType});
+    const action = parameterStationMappingActions.loadParameterStationMappingsForCollections({collectionAssets, measurementDataType});
 
     const result = parameterStationMappingFeature.reducer(state, action);
 
@@ -25,7 +34,7 @@ describe('ParameterStationMapping Reducer', () => {
 
   it('should not change loadingState if it is already loaded when loadParameterStationMappingForCollections is dispatched', () => {
     state[measurementDataType].loadingState = 'loaded';
-    const action = parameterStationMappingActions.loadParameterStationMappingsForCollections({collections: ['test'], measurementDataType});
+    const action = parameterStationMappingActions.loadParameterStationMappingsForCollections({collectionAssets, measurementDataType});
 
     const result = parameterStationMappingFeature.reducer(state, action);
 

--- a/src/app/state/parameters/actions/parameter.action.ts
+++ b/src/app/state/parameters/actions/parameter.action.ts
@@ -1,4 +1,5 @@
 import {createActionGroup, props} from '@ngrx/store';
+import {CollectionAsset} from '../../../shared/models/collection-assets';
 import {MeasurementDataType} from '../../../shared/models/measurement-data-type';
 import type {Parameter} from '../../../shared/models/parameter';
 
@@ -6,7 +7,10 @@ export const parameterActions = createActionGroup({
   source: 'Parameters',
   events: {
     'Set loaded parameters': props<{parameters: Parameter[]; measurementDataType: MeasurementDataType}>(),
-    'Load parameters for collections': props<{collections: string[]; measurementDataType: MeasurementDataType}>(),
+    'Load parameters for collections': props<{
+      collectionAssets: CollectionAsset[];
+      measurementDataType: MeasurementDataType;
+    }>(),
     'Set parameter loading error': props<{error?: unknown; measurementDataType: MeasurementDataType}>(),
   },
 });

--- a/src/app/state/parameters/effects/parameter.effects.ts
+++ b/src/app/state/parameters/effects/parameter.effects.ts
@@ -12,8 +12,10 @@ import {selectCurrentParameterState} from '../selectors/parameter.selector';
 export const loadCollectionParameters = createEffect(
   (actions$ = inject(Actions)) => {
     return actions$.pipe(
-      ofType(collectionActions.loadCollections),
-      map(({measurementDataType, collections}) => parameterActions.loadParametersForCollections({collections, measurementDataType})),
+      ofType(collectionActions.setCollectionAssets),
+      map(({measurementDataType, assets}) =>
+        parameterActions.loadParametersForCollections({collectionAssets: assets, measurementDataType}),
+      ),
     );
   },
   {functional: true},
@@ -25,8 +27,8 @@ export const loadParameters = createEffect(
       ofType(parameterActions.loadParametersForCollections),
       concatLatestFrom(() => store.select(selectCurrentParameterState)),
       filter(([_, parameterState]) => parameterState.loadingState !== 'loaded'),
-      switchMap(([{collections, measurementDataType}]) =>
-        from(parameterService.loadParameterForCollections(collections)).pipe(
+      switchMap(([{collectionAssets, measurementDataType}]) =>
+        from(parameterService.loadParameterForCollections(collectionAssets)).pipe(
           map((parameters) => parameterActions.setLoadedParameters({parameters, measurementDataType})),
           catchError((error: unknown) => of(parameterActions.setParameterLoadingError({error, measurementDataType}))),
         ),

--- a/src/app/state/parameters/reducers/parameter.reducer.spec.ts
+++ b/src/app/state/parameters/reducers/parameter.reducer.spec.ts
@@ -1,4 +1,5 @@
 import {collectionConfig} from '../../../shared/configs/collections.config';
+import {CollectionAsset} from '../../../shared/models/collection-assets';
 import {measurementDataTypes} from '../../../shared/models/measurement-data-type';
 import {Parameter} from '../../../shared/models/parameter';
 import {parameterActions} from '../actions/parameter.action';
@@ -12,6 +13,14 @@ describe('Parameter Reducer', () => {
     {
       id: 'test-parameter-id',
       group: {de: 'test-group', en: 'test-group', fr: 'test-group', it: 'test-group'},
+    },
+  ];
+  const collectionAssets: CollectionAsset[] = [
+    {
+      filename: 'stations.csv',
+      metaFileType: 'station',
+      url: 'station://',
+      collection: 'test',
     },
   ];
 
@@ -35,7 +44,7 @@ describe('Parameter Reducer', () => {
 
   it('should set loadingState to loading when loadParameterForCollections is dispatched and loading state is currently not loaded', () => {
     state[measurementDataType].loadingState = 'error';
-    const action = parameterActions.loadParametersForCollections({collections: ['test'], measurementDataType});
+    const action = parameterActions.loadParametersForCollections({collectionAssets, measurementDataType});
 
     const result = parameterFeature.reducer(state, action);
 
@@ -45,7 +54,7 @@ describe('Parameter Reducer', () => {
 
   it('should not change loadingState if it is already loaded when loadParameterForCollections is dispatched', () => {
     state[measurementDataType].loadingState = 'loaded';
-    const action = parameterActions.loadParametersForCollections({collections: ['test'], measurementDataType});
+    const action = parameterActions.loadParametersForCollections({collectionAssets, measurementDataType});
 
     const result = parameterFeature.reducer(state, action);
 

--- a/src/app/state/stations/actions/station.action.ts
+++ b/src/app/state/stations/actions/station.action.ts
@@ -1,4 +1,5 @@
 import {createActionGroup, props} from '@ngrx/store';
+import {CollectionAsset} from '../../../shared/models/collection-assets';
 import {MeasurementDataType} from '../../../shared/models/measurement-data-type';
 import {Station} from '../../../shared/models/station';
 
@@ -6,7 +7,10 @@ export const stationActions = createActionGroup({
   source: 'Stations',
   events: {
     'Set loaded stations': props<{stations: Station[]; measurementDataType: MeasurementDataType}>(),
-    'Load stations for collections': props<{collections: string[]; measurementDataType: MeasurementDataType}>(),
+    'Load stations for collections': props<{
+      collectionAssets: CollectionAsset[];
+      measurementDataType: MeasurementDataType;
+    }>(),
     'Set station loading error': props<{error?: unknown; measurementDataType: MeasurementDataType}>(),
   },
 });

--- a/src/app/state/stations/effects/station.effects.spec.ts
+++ b/src/app/state/stations/effects/station.effects.spec.ts
@@ -10,9 +10,18 @@ import {collectionActions} from '../../collection/actions/collection.action';
 import {stationActions} from '../actions/station.action';
 import {selectCurrentStationState} from '../selectors/station.selector';
 import {failLoadingCollectionStations, loadCollectionStations, loadStations} from './station.effects';
+import type {CollectionAsset} from '../../../shared/models/collection-assets';
 
 describe('StationEffects', () => {
   const measurementDataType = collectionConfig.defaultMeasurementDataType;
+  const collectionAssets: CollectionAsset[] = [
+    {
+      filename: 'stations.csv',
+      metaFileType: 'station',
+      url: 'station://',
+      collection: 'test',
+    },
+  ];
 
   let actions$: Observable<Action>;
   let store: MockStore;
@@ -32,10 +41,9 @@ describe('StationEffects', () => {
   });
 
   it('should dispatch loadStations action when loadCollection is dispatched', (done: DoneFn) => {
-    const collections = ['collection'];
-    actions$ = of(collectionActions.loadCollections({collections, measurementDataType}));
+    actions$ = of(collectionActions.setCollectionAssets({assets: collectionAssets, measurementDataType}));
     loadCollectionStations(actions$).subscribe((action) => {
-      expect(action).toEqual(stationActions.loadStationsForCollections({collections, measurementDataType}));
+      expect(action).toEqual(stationActions.loadStationsForCollections({collectionAssets, measurementDataType}));
       done();
     });
   });
@@ -43,7 +51,7 @@ describe('StationEffects', () => {
   it('should dispatch the setStations action when loading stations for collections', (done: DoneFn) => {
     spyOn(stationService, 'loadStationsForCollections').and.resolveTo([]);
     store.overrideSelector(selectCurrentStationState, {stations: [], loadingState: undefined});
-    actions$ = of(stationActions.loadStationsForCollections({collections: ['collection'], measurementDataType}));
+    actions$ = of(stationActions.loadStationsForCollections({collectionAssets, measurementDataType}));
 
     loadStations(actions$, store, stationService).subscribe((action) => {
       expect(action).toEqual(stationActions.setLoadedStations({stations: [], measurementDataType}));
@@ -54,7 +62,7 @@ describe('StationEffects', () => {
   it('should not call the service if the data is already loaded', (done: DoneFn) => {
     spyOn(stationService, 'loadStationsForCollections');
     store.overrideSelector(selectCurrentStationState, {stations: [], loadingState: 'loaded'});
-    actions$ = of(stationActions.loadStationsForCollections({collections: ['collection'], measurementDataType}));
+    actions$ = of(stationActions.loadStationsForCollections({collectionAssets, measurementDataType}));
 
     loadStations(actions$, store, stationService).subscribe({
       complete: () => {
@@ -68,7 +76,7 @@ describe('StationEffects', () => {
     const error = new Error('test');
     spyOn(stationService, 'loadStationsForCollections').and.rejectWith(error);
     store.overrideSelector(selectCurrentStationState, {stations: [], loadingState: undefined});
-    actions$ = of(stationActions.loadStationsForCollections({collections: ['collection'], measurementDataType}));
+    actions$ = of(stationActions.loadStationsForCollections({collectionAssets, measurementDataType}));
 
     loadStations(actions$, store, stationService).subscribe((action) => {
       expect(action).toEqual(stationActions.setStationLoadingError({error, measurementDataType}));

--- a/src/app/state/stations/effects/station.effects.ts
+++ b/src/app/state/stations/effects/station.effects.ts
@@ -12,8 +12,8 @@ import {selectCurrentStationState} from '../selectors/station.selector';
 export const loadCollectionStations = createEffect(
   (actions$ = inject(Actions)) => {
     return actions$.pipe(
-      ofType(collectionActions.loadCollections),
-      map(({measurementDataType, collections}) => stationActions.loadStationsForCollections({collections, measurementDataType})),
+      ofType(collectionActions.setCollectionAssets),
+      map(({measurementDataType, assets}) => stationActions.loadStationsForCollections({collectionAssets: assets, measurementDataType})),
     );
   },
   {functional: true},
@@ -25,8 +25,8 @@ export const loadStations = createEffect(
       ofType(stationActions.loadStationsForCollections),
       concatLatestFrom(() => store.select(selectCurrentStationState)),
       filter(([_, stationState]) => stationState.loadingState !== 'loaded'),
-      switchMap(([{collections, measurementDataType}]) =>
-        from(stationService.loadStationsForCollections(collections)).pipe(
+      switchMap(([{collectionAssets, measurementDataType}]) =>
+        from(stationService.loadStationsForCollections(collectionAssets)).pipe(
           map((stations) => stationActions.setLoadedStations({stations, measurementDataType})),
           catchError((error: unknown) => of(stationActions.setStationLoadingError({error, measurementDataType}))),
         ),

--- a/src/app/state/stations/reducers/station.reducer.spec.ts
+++ b/src/app/state/stations/reducers/station.reducer.spec.ts
@@ -1,11 +1,20 @@
 import {collectionConfig} from '../../../shared/configs/collections.config';
 import {stationActions} from '../actions/station.action';
 import {initialState, stationFeature} from './station.reducer';
+import type {CollectionAsset} from '../../../shared/models/collection-assets';
 import type {Station} from '../../../shared/models/station';
 import type {StationState} from '../states/station.state';
 
 describe('Station Reducer', () => {
   const measurementDataType = collectionConfig.defaultMeasurementDataType;
+  const collectionAssets: CollectionAsset[] = [
+    {
+      filename: 'stations.csv',
+      metaFileType: 'station',
+      url: 'station://',
+      collection: 'test',
+    },
+  ];
 
   let state: StationState;
 
@@ -15,7 +24,7 @@ describe('Station Reducer', () => {
 
   it('should set loadingState to loading when loadStationForCollections is dispatched and loading state is currently not loaded', () => {
     state[measurementDataType].loadingState = 'error';
-    const action = stationActions.loadStationsForCollections({collections: ['test'], measurementDataType});
+    const action = stationActions.loadStationsForCollections({collectionAssets, measurementDataType});
 
     const result = stationFeature.reducer(state, action);
 
@@ -25,7 +34,7 @@ describe('Station Reducer', () => {
 
   it('should not change loadingState if it is already loaded when loadStationForCollections is dispatched', () => {
     state[measurementDataType].loadingState = 'loaded';
-    const action = stationActions.loadStationsForCollections({collections: ['test'], measurementDataType});
+    const action = stationActions.loadStationsForCollections({collectionAssets, measurementDataType});
 
     const result = stationFeature.reducer(state, action);
 


### PR DESCRIPTION
Similar to stations a collection can contain assets. In fact for our application it is crucial to retrieve them as they contain the links to the meta CSV files that is needed to display all necessary values. As there are multiple parts of the application that depend on this information we put the collection assets into the store so they can be used again.

This allows us to use  these values to load all other data. The collection assets contain the url to retrieve the meta CSV.

This PR depends on #35 