### PR TITLE
Fix app initialization #53

### DIFF
--- a/src/app/data-selection-form/data-selection-form.component.ts
+++ b/src/app/data-selection-form/data-selection-form.component.ts
@@ -1,12 +1,11 @@
 import {AsyncPipe} from '@angular/common';
-import {Component, inject, OnInit} from '@angular/core';
+import {Component, inject} from '@angular/core';
 import {MatButton} from '@angular/material/button';
 import {MatButtonToggle, MatButtonToggleGroup} from '@angular/material/button-toggle';
 import {MatStepperModule} from '@angular/material/stepper';
 import {TranslocoModule} from '@jsverse/transloco';
 import {Store} from '@ngrx/store';
 import {MapContainerComponent} from '../map/components/map-container/map-container.component';
-import {collectionConfig} from '../shared/configs/collections.config';
 import {MeasurementDataType} from '../shared/models/measurement-data-type';
 import {appActions} from '../state/app/actions/app.actions';
 import {formActions} from '../state/form/actions/form.actions';
@@ -41,18 +40,13 @@ import type {Language} from '../shared/models/language';
   templateUrl: './data-selection-form.component.html',
   styleUrl: './data-selection-form.component.scss',
 })
-export class DataSelectionFormComponent implements OnInit {
+export class DataSelectionFormComponent {
   private readonly store = inject(Store);
 
-  protected readonly selectSelectedStationId$ = this.store.select(formFeature.selectSelectedStationId);
   protected readonly selectedSelectedDataInterval$ = this.store.select(formFeature.selectSelectedDataInterval);
   protected readonly selectedSelectedTimeRange$ = this.store.select(formFeature.selectSelectedTimeRange);
   protected readonly selectedMeasurementDataType$ = this.store.select(formFeature.selectSelectedMeasurementDataType);
   protected readonly selectedCollection$ = this.store.select(formFeature.selectSelectedCollection);
-
-  public ngOnInit(): void {
-    this.store.dispatch(formActions.setSelectedMeasurementDataType({measurementDataType: collectionConfig.defaultMeasurementDataType}));
-  }
 
   protected changeLanguage(language: Language): void {
     this.store.dispatch(appActions.setLanguage({language}));

--- a/src/app/state/app/actions/app.actions.ts
+++ b/src/app/state/app/actions/app.actions.ts
@@ -5,6 +5,7 @@ import {Language} from '../../../shared/models/language';
 export const appActions = createActionGroup({
   source: 'App',
   events: {
+    'Initialize language': props<{language: Language}>(),
     'Set language': props<{language: Language}>(),
     'Initialize app': props<{parameter: AppUrlParameter}>(),
   },

--- a/src/app/state/app/effects/app.effects.spec.ts
+++ b/src/app/state/app/effects/app.effects.spec.ts
@@ -26,10 +26,10 @@ describe('AppEffects', () => {
     });
   });
 
-  it('should dispatch setLanguage action when appActions.initializeApp is dispatched', (done: DoneFn) => {
+  it('should dispatch initializeLanguage action when appActions.initializeApp is dispatched', (done: DoneFn) => {
     actions$ = of(appActions.initializeApp({parameter: {language: 'fr'} as AppUrlParameter}));
     initializeLanguage(actions$).subscribe((action) => {
-      expect(action).toEqual(appActions.setLanguage({language: 'fr'}));
+      expect(action).toEqual(appActions.initializeLanguage({language: 'fr'}));
       done();
     });
   });

--- a/src/app/state/app/effects/app.effects.ts
+++ b/src/app/state/app/effects/app.effects.ts
@@ -7,7 +7,7 @@ import {appActions} from '../actions/app.actions';
 export const setLanguage = createEffect(
   (actions$ = inject(Actions), translocoService = inject(TranslocoService)) => {
     return actions$.pipe(
-      ofType(appActions.setLanguage),
+      ofType(appActions.setLanguage, appActions.initializeLanguage),
       tap(({language}) => translocoService.setActiveLang(language)),
     );
   },
@@ -18,7 +18,7 @@ export const initializeLanguage = createEffect(
   (actions$ = inject(Actions)) => {
     return actions$.pipe(
       ofType(appActions.initializeApp),
-      map(({parameter}) => appActions.setLanguage({language: parameter.language})),
+      map(({parameter}) => appActions.initializeLanguage({language: parameter.language})),
     );
   },
   {functional: true},

--- a/src/app/state/app/reducers/app.reducer.spec.ts
+++ b/src/app/state/app/reducers/app.reducer.spec.ts
@@ -13,6 +13,17 @@ describe('App Reducer', () => {
     };
   });
 
+  it('should initialize the language without changing anything else', () => {
+    const action = appActions.initializeLanguage({language: 'de'});
+
+    const result = appFeature.reducer(state, action);
+
+    expect(result).toEqual({
+      ...state,
+      language: 'de',
+    });
+  });
+
   it('should set the given language', () => {
     const action = appActions.setLanguage({language: 'de'});
 

--- a/src/app/state/app/reducers/app.reducer.ts
+++ b/src/app/state/app/reducers/app.reducer.ts
@@ -15,6 +15,13 @@ export const appFeature = createFeature({
   reducer: createReducer(
     initialState,
     on(
+      appActions.initializeLanguage,
+      (state, {language}): AppState => ({
+        ...state,
+        language,
+      }),
+    ),
+    on(
       appActions.setLanguage,
       (state, {language}): AppState => ({
         ...state,

--- a/src/app/state/assets/effects/asset.effects.ts
+++ b/src/app/state/assets/effects/asset.effects.ts
@@ -12,7 +12,7 @@ import {assetActions} from '../actions/asset.actions';
 export const loadAssetsForStation = createEffect(
   (actions$ = inject(Actions), store = inject(Store), assetService = inject(AssetService)) => {
     return actions$.pipe(
-      ofType(formActions.setSelectedCollection, formActions.setSelectedParameterGroupAndStationIdAndCollection),
+      ofType(formActions.setSelectedCollection, formActions.initializeSelectedParameterGroupAndStationIdAndCollection),
       concatLatestFrom(() => store.select(formFeature.selectFormState)),
       map(([_, {selectedStationId, selectedCollection}]) => ({selectedStationId, selectedCollection})),
       // use distinctUntilChanged to prevent unnecessary API calls
@@ -34,7 +34,7 @@ export const loadAssetsForStation = createEffect(
 export const resetAssets = createEffect(
   (actions$ = inject(Actions), store = inject(Store)) => {
     return actions$.pipe(
-      ofType(formActions.setSelectedCollection, formActions.setSelectedParameterGroupAndStationIdAndCollection),
+      ofType(formActions.setSelectedCollection, formActions.initializeSelectedParameterGroupAndStationIdAndCollection),
       concatLatestFrom(() => store.select(formFeature.selectFormState)),
       filter(([, {selectedStationId, selectedCollection}]) => !selectedStationId || !selectedCollection),
       map(() => assetActions.resetState()),

--- a/src/app/state/form/actions/form.actions.ts
+++ b/src/app/state/form/actions/form.actions.ts
@@ -7,13 +7,14 @@ import type {TimeRange} from '../../../shared/models/time-range';
 export const formActions = createActionGroup({
   source: 'Form',
   events: {
-    'Set selected parameters': props<{parameterGroupId: string | null}>(),
-    'Set selected station id': props<{stationId: string | null}>(),
-    'Set selected parameter group and station id and collection': props<{
+    'Initialize selected measurement data type': props<{measurementDataType: MeasurementDataType}>(),
+    'Initialize selected parameter group and station id and collection': props<{
       parameterGroupId: string | null;
       stationId: string | null;
       collection: string | null;
     }>(),
+    'Set selected parameters': props<{parameterGroupId: string | null}>(),
+    'Set selected station id': props<{stationId: string | null}>(),
     'Set selected dataInterval': props<{dataInterval: DataInterval}>(),
     'Set selected time range': props<{timeRange: TimeRange; historicalDateRange: DateRange | null}>(),
     'Set selected measurement data type': props<{measurementDataType: MeasurementDataType}>(),

--- a/src/app/state/form/effects/form.effects.spec.ts
+++ b/src/app/state/form/effects/form.effects.spec.ts
@@ -59,10 +59,10 @@ describe('FormEffects', () => {
     });
   });
 
-  it('should dispatch setSelectedMeasurementDataType action when initializeApp is dispatched', (done: DoneFn) => {
+  it('should dispatch initializeSelectedMeasurementDataType action when initializeApp is dispatched', (done: DoneFn) => {
     actions$ = of(appActions.initializeApp({parameter: {measurementDataType: 'homogenous'} as AppUrlParameter}));
     initializeSelectedMeasurementDataType(actions$).subscribe((action) => {
-      expect(action).toEqual(formActions.setSelectedMeasurementDataType({measurementDataType: 'homogenous'}));
+      expect(action).toEqual(formActions.initializeSelectedMeasurementDataType({measurementDataType: 'homogenous'}));
       done();
     });
   });
@@ -85,13 +85,17 @@ describe('FormEffects', () => {
       store.overrideSelector(selectParameterGroups, [{id: '123', name: {de: 'de', fr: 'fr', it: 'it', en: 'en'}}]);
     });
 
-    it('should dispatch setSelectedParameterGroupAndStationIdAndCollection action when initializeApp is dispatched', (done) => {
+    it('should dispatch initializeSelectedParameterGroupAndStationIdAndCollection action when initializeApp is dispatched', (done) => {
       actions$ = of(
         appActions.initializeApp({parameter: {parameterGroupId: '123', stationId: '456', collection: '789'} as AppUrlParameter}),
       );
       initializeSelectedStationIdAndParameterGroupIdAndCollection(actions$, store).subscribe((action) => {
         expect(action).toEqual(
-          formActions.setSelectedParameterGroupAndStationIdAndCollection({parameterGroupId: '123', stationId: '456', collection: '789'}),
+          formActions.initializeSelectedParameterGroupAndStationIdAndCollection({
+            parameterGroupId: '123',
+            stationId: '456',
+            collection: '789',
+          }),
         );
         done();
       });
@@ -103,7 +107,11 @@ describe('FormEffects', () => {
       );
       initializeSelectedStationIdAndParameterGroupIdAndCollection(actions$, store).subscribe((action) => {
         expect(action).toEqual(
-          formActions.setSelectedParameterGroupAndStationIdAndCollection({parameterGroupId: '123', stationId: null, collection: null}),
+          formActions.initializeSelectedParameterGroupAndStationIdAndCollection({
+            parameterGroupId: '123',
+            stationId: null,
+            collection: null,
+          }),
         );
         done();
       });
@@ -115,7 +123,11 @@ describe('FormEffects', () => {
       );
       initializeSelectedStationIdAndParameterGroupIdAndCollection(actions$, store).subscribe((action) => {
         expect(action).toEqual(
-          formActions.setSelectedParameterGroupAndStationIdAndCollection({parameterGroupId: null, stationId: '456', collection: null}),
+          formActions.initializeSelectedParameterGroupAndStationIdAndCollection({
+            parameterGroupId: null,
+            stationId: '456',
+            collection: null,
+          }),
         );
         done();
       });

--- a/src/app/state/form/effects/form.effects.ts
+++ b/src/app/state/form/effects/form.effects.ts
@@ -15,7 +15,7 @@ import {selectSelectedStationWithParameterGroupsFilteredBySelectedParameterGroup
 export const loadCollectionsForSelectedMeasurementDataType = createEffect(
   (actions$ = inject(Actions)) => {
     return actions$.pipe(
-      ofType(formActions.setSelectedMeasurementDataType),
+      ofType(formActions.setSelectedMeasurementDataType, formActions.initializeSelectedMeasurementDataType),
       map(({measurementDataType}) =>
         collectionActions.loadCollections({measurementDataType, collections: collectionConfig.collections[measurementDataType]}),
       ),
@@ -39,7 +39,7 @@ export const initializeSelectedMeasurementDataType = createEffect(
   (actions$ = inject(Actions)) => {
     return actions$.pipe(
       ofType(appActions.initializeApp),
-      map(({parameter}) => formActions.setSelectedMeasurementDataType({measurementDataType: parameter.measurementDataType})),
+      map(({parameter}) => formActions.initializeSelectedMeasurementDataType({measurementDataType: parameter.measurementDataType})),
     );
   },
   {functional: true},
@@ -64,7 +64,7 @@ export const initializeSelectedStationIdAndParameterGroupIdAndCollection = creat
         const collection =
           stations.filter((station) => station.id === stationId).find((station) => station.collection === parameter.collection)
             ?.collection ?? null;
-        return formActions.setSelectedParameterGroupAndStationIdAndCollection({parameterGroupId, stationId, collection});
+        return formActions.initializeSelectedParameterGroupAndStationIdAndCollection({parameterGroupId, stationId, collection});
       }),
     );
   },

--- a/src/app/state/form/reducers/form.reducer.spec.ts
+++ b/src/app/state/form/reducers/form.reducer.spec.ts
@@ -17,6 +17,14 @@ describe('Form Reducer', () => {
     };
   });
 
+  it('should initialize measurement data type without changing anything else', () => {
+    const action = formActions.initializeSelectedMeasurementDataType({measurementDataType: 'homogenous'});
+
+    const result = formFeature.reducer(state, action);
+
+    expect(result).toEqual({...state, selectedMeasurementDataType: 'homogenous'});
+  });
+
   it('should reset the form state when a measurement data type is selected', () => {
     const action = formActions.setSelectedMeasurementDataType({measurementDataType: 'homogenous'});
 
@@ -50,8 +58,8 @@ describe('Form Reducer', () => {
     });
   });
 
-  it('should reset selection of upcoming steps if parameter group ID and station ID are selected', () => {
-    const action = formActions.setSelectedParameterGroupAndStationIdAndCollection({
+  it('should initialize parameter group and station ID and collection without changing anything else', () => {
+    const action = formActions.initializeSelectedParameterGroupAndStationIdAndCollection({
       parameterGroupId: 'paramGroupTest',
       stationId: 'stationTest',
       collection: 'collectionTest',
@@ -60,8 +68,7 @@ describe('Form Reducer', () => {
     const result = formFeature.reducer(state, action);
 
     expect(result).toEqual({
-      ...initialState,
-      selectedMeasurementDataType: 'normal',
+      ...state,
       selectedParameterGroupId: 'paramGroupTest',
       selectedStationId: 'stationTest',
       selectedCollection: 'collectionTest',

--- a/src/app/state/form/reducers/form.reducer.ts
+++ b/src/app/state/form/reducers/form.reducer.ts
@@ -20,6 +20,19 @@ export const formFeature = createFeature({
   reducer: createReducer(
     initialState,
     on(
+      formActions.initializeSelectedMeasurementDataType,
+      (state, {measurementDataType}): FormState => ({...state, selectedMeasurementDataType: measurementDataType}),
+    ),
+    on(
+      formActions.initializeSelectedParameterGroupAndStationIdAndCollection,
+      (state, {parameterGroupId, stationId, collection}): FormState => ({
+        ...state,
+        selectedParameterGroupId: parameterGroupId,
+        selectedStationId: stationId,
+        selectedCollection: collection,
+      }),
+    ),
+    on(
       formActions.setSelectedMeasurementDataType,
       (_, {measurementDataType}): FormState => ({...initialState, selectedMeasurementDataType: measurementDataType}),
     ),
@@ -43,18 +56,6 @@ export const formFeature = createFeature({
         selectedDataInterval: null,
         selectedTimeRange: null,
         selectedCollection: null,
-        selectedHistoricalDateRange: null,
-      }),
-    ),
-    on(
-      formActions.setSelectedParameterGroupAndStationIdAndCollection,
-      (state, {parameterGroupId, stationId, collection}): FormState => ({
-        ...state,
-        selectedParameterGroupId: parameterGroupId,
-        selectedStationId: stationId,
-        selectedCollection: collection,
-        selectedDataInterval: null,
-        selectedTimeRange: null,
         selectedHistoricalDateRange: null,
       }),
     ),

--- a/src/app/state/map/effects/map.effects.ts
+++ b/src/app/state/map/effects/map.effects.ts
@@ -81,7 +81,7 @@ export const filterStationsOnMap = createEffect(
       ofType(
         formActions.setSelectedParameters,
         mapActions.completeLayersInitialization,
-        formActions.setSelectedParameterGroupAndStationIdAndCollection,
+        formActions.initializeSelectedParameterGroupAndStationIdAndCollection,
       ),
       concatLatestFrom(() => store.select(mapFeature.selectMapsState)),
       filter(([, {loadingState, areLayersInitialized}]) => loadingState === 'loaded' && areLayersInitialized),
@@ -115,7 +115,7 @@ export const highlightSelectedStationOnMap = createEffect(
         formActions.setSelectedStationId,
         formActions.setSelectedParameters,
         mapActions.setMapAsLoaded,
-        formActions.setSelectedParameterGroupAndStationIdAndCollection,
+        formActions.initializeSelectedParameterGroupAndStationIdAndCollection,
       ),
       concatLatestFrom(() => store.select(mapFeature.selectLoadingState)),
       filter(([, loadingState]) => loadingState === 'loaded'),


### PR DESCRIPTION
There is a distinct init-action for each initial parameter to make sure that there is no loop back to setting the URL while the app is not yet finished initializing. These actions don't change the state apart from their value.

Also the default value from `data-selection-form.component` was removed. This is set within the app initialization using the URL fragment or default values if the fragment is empty/invalid.