### PR TITLE
Error handler logs error messages in localhost

### DIFF
--- a/src/app/error-handling/error-handler.service.spec.ts
+++ b/src/app/error-handling/error-handler.service.spec.ts
@@ -115,7 +115,7 @@ describe('ErrorHandlerService', () => {
       service.handleError(testError);
 
       expect(console.warn).not.toHaveBeenCalled();
-      expect(console.error).toHaveBeenCalledOnceWith(testError);
+      expect(console.error).toHaveBeenCalledOnceWith(testError, '');
     });
 
     it('logs a OpendataExplorerRuntimeError to the console if it has no wrapped error', () => {
@@ -125,7 +125,7 @@ describe('ErrorHandlerService', () => {
       service.handleError(testError);
 
       expect(console.warn).not.toHaveBeenCalled();
-      expect(console.error).toHaveBeenCalledOnceWith(testError);
+      expect(console.error).toHaveBeenCalledOnceWith(testError, '');
     });
 
     it('logs a OpendataExplorerRuntimeError to the console and also logs a wrapped error', () => {
@@ -136,7 +136,7 @@ describe('ErrorHandlerService', () => {
       service.handleError(testError);
 
       expect(console.error).toHaveBeenCalledTimes(2);
-      expect(console.error).toHaveBeenCalledWith(testError);
+      expect(console.error).toHaveBeenCalledWith(testError, '');
       expect(console.error).toHaveBeenCalledWith('Original error was:', testWrappedError);
     });
   });

--- a/src/app/error-handling/error-handler.service.ts
+++ b/src/app/error-handling/error-handler.service.ts
@@ -19,26 +19,30 @@ export class ErrorHandlerService implements ErrorHandler {
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- The interface definition of angular error-handlers defines any as an argument.
   public handleError(error: any): void {
+    let message: string;
+    if (error instanceof Error) {
+      message =
+        error instanceof OpendataExplorerRuntimeError
+          ? this.translocoService.translate(error.message, error.translationArguments)
+          : error.message;
+    } else {
+      message = JSON.stringify(error);
+    }
+
     // log errors to console for easier debugging in non-productive environments
     if (this.angularDevModeService.isDevMode()) {
-      console.error(error);
-
+      console.error(error, message);
       if (error instanceof OpendataExplorerRuntimeError && error.originalError) {
         console.error('Original error was:', error.originalError);
       }
     }
-    const translatedMessage =
-      error instanceof OpendataExplorerRuntimeError
-        ? this.translocoService.translate(error.message, error.translationArguments)
-        : error instanceof Error
-          ? error.message
-          : JSON.stringify(error);
+
     if (error instanceof SilentError) {
       // these errors should only be logged to a frontend logging service, but not displayed.
     } else if (error instanceof RecoverableError) {
       // At the moment, recoverable errors are treated the same as silent errors.
     } else {
-      this.routeToErrorPage(translatedMessage);
+      this.routeToErrorPage(message);
     }
   }
 


### PR DESCRIPTION
Console error messages contain now the error message as well:
![image](https://github.com/user-attachments/assets/fd668436-7852-4769-8086-273d70bb3603)