### PR TITLE
Parse assets without time-range #75

### DIFF
--- a/src/app/stac/service/asset.service.spec.ts
+++ b/src/app/stac/service/asset.service.spec.ts
@@ -147,5 +147,41 @@ describe('AssetService', () => {
         ]),
       );
     });
+
+    it('should parse filenames with no timeRange (no-type)', async () => {
+      const collection = 'collection';
+      const stationId = 'stationId';
+      stacApiService.getAssets.and.resolveTo([
+        {filename: `${collection}_${stationId}_t.csv`, url: 'www.meteoschweiz.admin.ch'},
+        {filename: `${collection}_${stationId}_m.csv`, url: 'www.meteoschweiz.admin.ch'},
+        {filename: `${collection}_${stationId}_y.csv`, url: 'www.meteoschweiz.admin.ch'},
+      ]);
+
+      const result = await service.loadStationAssets(collection, stationId);
+
+      expect(result).toEqual([
+        {
+          filename: `${collection}_${stationId}_t.csv`,
+          url: 'www.meteoschweiz.admin.ch',
+          interval: 'ten-minutes',
+          timeRange: 'historical',
+          dateRange: undefined,
+        },
+        {
+          filename: `${collection}_${stationId}_m.csv`,
+          url: 'www.meteoschweiz.admin.ch',
+          interval: 'monthly',
+          timeRange: 'historical',
+          dateRange: undefined,
+        },
+        {
+          filename: `${collection}_${stationId}_y.csv`,
+          url: 'www.meteoschweiz.admin.ch',
+          interval: 'yearly',
+          timeRange: 'historical',
+          dateRange: undefined,
+        },
+      ] satisfies StationAsset[]);
+    });
   });
 });


### PR DESCRIPTION
Monthly and yearly assets do not have a distinction between now and recent, which is why they omit the time-range part fully in the file names. They always contain all data. To a user this is basically the same as historical assets, even though according to the definition of historical this is not quite correct. Historical data normally only contain data until Dec 31th of the previous year. So in case of monthly data its not quite right. But users probably won't notice. This is why these assets are treated the same as historical assets without a date-range.