### PR TITLE
Fix styling of tooltips not taking effect #85

### DIFF
--- a/src/styles/_overrides.scss
+++ b/src/styles/_overrides.scss
@@ -19,7 +19,7 @@ a {
   );
 }
 
-.mat-mdc-tooltip-surface {
+mat-tooltip-component .mat-mdc-tooltip-surface {
   padding: 15px;
   max-width: 500px;
 }


### PR DESCRIPTION
Material styles are applied after our override styles are applied. This means that the material style for `mat-mdc-tooltip-surface` is not applied.

CSS styles follow a defined precedence. Styles applied later take precedence over styles applied earlier. But also more specific selectors for styles take precedence over less specific selectors. So to make our overrides work we just have to use a more specific selector. Using `mat-tooltip-component .mat-mdc-tooltip-surface` makes it more specific and also describes that the class should only be applied to material tooltip components.