### PR TITLE
Parse windows-1252 encoded CSV #83

### DIFF
--- a/public/i18n/de.json
+++ b/public/i18n/de.json
@@ -18,6 +18,7 @@
   "form.stepper.download.label": "Die Daten herunterladen",
   "form.time-range.now": "Heute",
   "form.time-range.now.explanation": "Alle Werte seit Mitternacht",
+  "form.selection-not-available": "Nicht verfügbar für Ihre Auswahl",
   "form.time-range.recent": "Aktuelles Jahr",
   "form.time-range.recent.tooltip": "Enthält bis Ende Februar die Daten des Vorjahres",
   "form.time-range.recent.explanation": "Alle Werte bis gestern",
@@ -61,6 +62,7 @@
   "form.collection-selection.title": "Messnetz wählen",
   "station.load.error": "Missing value for 'station.load.error'",
   "stac.load.error": "Es konnten keine Assets für collectionId '{{collectionId}}' und stationId '{{stationId}}' abgerufen werden",
+  "stac.csv.error": "Laden von '{{csvFile}}' fehlgeschlagen",
   "parameter.load.error": "Fehler beim Laden der Parameter",
   "parameter-station-mapping.load.error": "Missing value for 'parameter-station-mapping.load.error'",
   "map.load.error": "Missing value for 'map.load.error'",
@@ -74,6 +76,5 @@
   "form.interval.hourly": "Stündlich",
   "form.interval.daily": "Täglich",
   "form.interval.monthly": "Monatlich",
-  "form.interval.yearly": "Jährlich",
-  "form.selection-not-available": "Nicht verfügbar für Ihre Auswahl"
+  "form.interval.yearly": "Jährlich"
 }

--- a/public/i18n/en.json
+++ b/public/i18n/en.json
@@ -18,6 +18,7 @@
   "form.stepper.download.label": "Download the data",
   "form.time-range.now": "Today",
   "form.time-range.now.explanation": "All values since midnight",
+  "form.selection-not-available": "Not available for your selection",
   "form.time-range.recent": "Current year",
   "form.time-range.recent.tooltip": "Contains the data of the previous year until the end of February",
   "form.time-range.recent.explanation": "All values up to yesterday",
@@ -61,6 +62,7 @@
   "form.collection-selection.title": "Select measuring network",
   "station.load.error": "Missing value for 'station.load.error'",
   "stac.load.error": "Failed to get assets for collectionId '{{collectionId}}' and stationId '{{stationId}}'",
+  "stac.csv.error": "Failed loading '{{csvFile}}'",
   "parameter.load.error": "Error loading parameters",
   "parameter-station-mapping.load.error": "Missing value for 'parameter-station-mapping.load.error'",
   "map.load.error": "Missing value for 'map.load.error'",
@@ -74,6 +76,5 @@
   "form.interval.hourly": "Hourly",
   "form.interval.daily": "Daily",
   "form.interval.monthly": "Monthly",
-  "form.interval.yearly": "Yearly",
-  "form.selection-not-available": "Not available for your selection"
+  "form.interval.yearly": "Yearly"
 }

--- a/public/i18n/fr.json
+++ b/public/i18n/fr.json
@@ -18,6 +18,7 @@
   "form.stepper.download.label": "Missing value for 'form.stepper.download.label'",
   "form.time-range.now": "Missing value for 'form.time-range.now'",
   "form.time-range.now.explanation": "Missing value for 'form.time-range.now.explanation'",
+  "form.selection-not-available": "Missing value for 'form.selection-not-available'",
   "form.time-range.recent": "Missing value for 'form.time-range.recent'",
   "form.time-range.recent.tooltip": "Missing value for 'form.time-range.recent.tooltip'",
   "form.time-range.recent.explanation": "Missing value for 'form.time-range.recent.explanation'",
@@ -61,6 +62,7 @@
   "form.collection-selection.title": "Missing value for 'form.collection-selection.title'",
   "station.load.error": "Missing value for 'station.load.error'",
   "stac.load.error": "Échec de la récupération des actifs pour collectionId '{{collectionId}}' et stationId '{{stationId}}'",
+  "stac.csv.error": "Échec du chargement de {{csvFile}}",
   "parameter.load.error": "Erreur lors du chargement des paramètres",
   "parameter-station-mapping.load.error": "Missing value for 'parameter-station-mapping.load.error'",
   "map.load.error": "Missing value for 'map.load.error'",
@@ -74,6 +76,5 @@
   "form.interval.hourly": "Missing value for 'form.interval.hourly'",
   "form.interval.daily": "Missing value for 'form.interval.daily'",
   "form.interval.monthly": "Missing value for 'form.interval.monthly'",
-  "form.interval.yearly": "Missing value for 'form.interval.yearly'",
-  "form.selection-not-available": "Missing value for 'form.selection-not-available'"
+  "form.interval.yearly": "Missing value for 'form.interval.yearly'"
 }

--- a/public/i18n/it.json
+++ b/public/i18n/it.json
@@ -18,6 +18,7 @@
   "form.stepper.download.label": "Missing value for 'form.stepper.download.label'",
   "form.time-range.now": "Missing value for 'form.time-range.now'",
   "form.time-range.now.explanation": "Missing value for 'form.time-range.now.explanation'",
+  "form.selection-not-available": "Missing value for 'form.selection-not-available'",
   "form.time-range.recent": "Missing value for 'form.time-range.recent'",
   "form.time-range.recent.tooltip": "Missing value for 'form.time-range.recent.tooltip'",
   "form.time-range.recent.explanation": "Missing value for 'form.time-range.recent.explanation'",
@@ -61,6 +62,7 @@
   "form.collection-selection.title": "Missing value for 'form.collection-selection.title'",
   "station.load.error": "Missing value for 'station.load.error'",
   "stac.load.error": "Impossibile ottenere le risorse per collectionId '{{collectionId}}' e stationId '{{stationId}}'",
+  "stac.csv.error": "Caricamento fallito di '{{csvFile}}'",
   "parameter.load.error": "Errore durante il caricamento dei parametri",
   "parameter-station-mapping.load.error": "Missing value for 'parameter-station-mapping.load.error'",
   "map.load.error": "Missing value for 'map.load.error'",
@@ -74,6 +76,5 @@
   "form.interval.hourly": "Missing value for 'form.interval.hourly'",
   "form.interval.daily": "Missing value for 'form.interval.daily'",
   "form.interval.monthly": "Missing value for 'form.interval.monthly'",
-  "form.interval.yearly": "Missing value for 'form.interval.yearly'",
-  "form.selection-not-available": "Missing value for 'form.selection-not-available'"
+  "form.interval.yearly": "Missing value for 'form.interval.yearly'"
 }

--- a/src/app/shared/configs/stac.config.ts
+++ b/src/app/shared/configs/stac.config.ts
@@ -1,6 +1,7 @@
 import type {StacClientConfig} from '../models/configs/stac-config';
 
-export const defaultStacClientConfig = {
+export const stacClientConfig = {
   baseUrl: 'https://data.geo.admin.ch/api/stac/v1',
   csvDelimiter: ';',
+  encoding: 'windows-1252',
 } as const satisfies StacClientConfig;

--- a/src/app/shared/errors/stac.error.ts
+++ b/src/app/shared/errors/stac.error.ts
@@ -13,3 +13,13 @@ export class StacLoadError extends FatalError {
     };
   }
 }
+
+export class StacCsvError extends FatalError {
+  public override message = marker('stac.csv.error');
+  public override translationArguments: Record<'csvFile', string>;
+
+  constructor(csvFile: string, originalError?: unknown) {
+    super(originalError);
+    this.translationArguments = {csvFile};
+  }
+}

--- a/src/app/shared/models/configs/stac-config.ts
+++ b/src/app/shared/models/configs/stac-config.ts
@@ -1,4 +1,5 @@
 export interface StacClientConfig {
   readonly baseUrl: string;
   readonly csvDelimiter: string;
+  readonly encoding: string;
 }


### PR DESCRIPTION
The users of the STAC api are likely to open the downloaded CSVs in Excel. Excel is not able to handle UTF-8 CSV-files correctly if they don't include the BOM. Currently it is unfortunately not possible to create the CSV with the UTF8-BOM, so in order for them to work in Excel without encoding issues they are encoded in windows-1252. This is an issue in JavaScript, as it expects all data to be UTF-8 encoded, as defined by the HTML5 standard. Special characters are then showed as a black question mark.

In order to mitigate this, the CSVs are first decoded using the Encoding API [0]. For this we need to read the bytes from the request, to make sure the encoding is preserved. Papaparse does not support this, so we have to fetch the data ourselves first, decode it and then provide it as a string to papaparse.

Currently, the encoding is hard-coded in the stat-client-config as windows-1252. There are ways to autodetect the encoding in Javascript in a browser, but due to time constraints it makes more sense to do that later when the STAC-api changes.

[0]: https://developer.mozilla.org/en-US/docs/Web/API/Encoding_API