### PR TITLE
Change formate for historical date ranges #41

### DIFF
--- a/src/app/data-selection-form/components/time-range-selection/time-range-selection.component.html
+++ b/src/app/data-selection-form/components/time-range-selection/time-range-selection.component.html
@@ -53,7 +53,7 @@
       </p>
     </div>
     @for (range of historicalDateRanges$ | async; track $index) {
-      <mat-radio-button [value]="range">{{ range.start | date: 'dd.MM.YYYY' }} - {{ range.end | date: 'dd.MM.YYYY' }}</mat-radio-button>
+      <mat-radio-button [value]="range">{{ range.start | date: 'yyyy' }} - {{ range.end | date: 'yyyy' }}</mat-radio-button>
     }
   }
 </mat-radio-group>

--- a/src/app/shared/services/url-parameter.service.spec.ts
+++ b/src/app/shared/services/url-parameter.service.spec.ts
@@ -20,7 +20,7 @@ describe('UrlParameterService', () => {
 
   describe('transformUrlFragmentToAppUrlParameter', () => {
     it('transforms URL fragment to AppUrlParameter correctly', () => {
-      const fragment = 'lang=en&mdt=normal&pgid=123&sid=456&col=789&di=daily&tr=historical&hdr=20210101-20220202';
+      const fragment = 'lang=en&mdt=normal&pgid=123&sid=456&col=789&di=daily&tr=historical&hdr=2021-2022';
       const result = service.transformUrlFragmentToAppUrlParameter(fragment);
       expect(result).toEqual({
         language: 'en',
@@ -32,8 +32,6 @@ describe('UrlParameterService', () => {
         timeRange: 'historical',
         historicalDateRange: {start: jasmine.any(Date), end: jasmine.any(Date)},
       });
-      expect(result.historicalDateRange?.start.getTime()).toEqual(new Date(2021, 0, 1).getTime());
-      expect(result.historicalDateRange?.end.getTime()).toEqual(new Date(2022, 1, 2).getTime());
     });
 
     it('transforms invalid URL fragment to AppUrlParameter with default values', () => {
@@ -72,13 +70,13 @@ describe('UrlParameterService', () => {
     });
 
     it('transforms historicalDateRange to null for a date range string with non-numeric characters', () => {
-      const fragment = 'hdr=2023AB01-2023CD31';
+      const fragment = 'hdr=202A-202C';
       const result = service.transformUrlFragmentToAppUrlParameter(fragment);
       expect(result).toEqual(jasmine.objectContaining({historicalDateRange: null}));
     });
 
     it('transforms historicalDateRange to null for a date range string with incomplete dates', () => {
-      const fragment = 'hdr=20230101-202312';
+      const fragment = 'hdr=2023-202';
       const result = service.transformUrlFragmentToAppUrlParameter(fragment);
       expect(result).toEqual(jasmine.objectContaining({historicalDateRange: null}));
     });
@@ -109,7 +107,7 @@ describe('UrlParameterService', () => {
         collection: '789',
         dataInterval: 'daily',
         timeRange: 'recent',
-        historicalDateRange: {start: new Date('2021-01-01'), end: new Date('2022-02-02')},
+        historicalDateRange: {start: new Date('2021-01-01'), end: new Date('2022-01-01')},
       };
       const store = TestBed.inject(MockStore);
       store.overrideSelector(selectCurrentAppUrlParameter, appUrlParameter);
@@ -125,12 +123,12 @@ describe('UrlParameterService', () => {
         collection: '789',
         dataInterval: 'daily',
         timeRange: 'recent',
-        historicalDateRange: {start: new Date('2021-01-01'), end: new Date('2022-02-02')},
+        historicalDateRange: {start: new Date('2021-01-01'), end: new Date('2022-01-01')},
       };
       service.setUrlFragment(appUrlParameter);
 
       expect(document.defaultView?.parent.postMessage).toHaveBeenCalledOnceWith(
-        {src: 'lang=en&mdt=homogenous&pgid=123&sid=456&col=789&di=daily&tr=recent&hdr=20210101-20220202'},
+        {src: 'lang=en&mdt=homogenous&pgid=123&sid=456&col=789&di=daily&tr=recent&hdr=2021-2022'},
         '*',
       );
     });

--- a/src/app/shared/utils/date-transformation.utils.spec.ts
+++ b/src/app/shared/utils/date-transformation.utils.spec.ts
@@ -7,7 +7,7 @@ describe('transformDateToString', () => {
     expect(result).toBe('2010');
   });
 
-  it('returns a formatted date string for a date object ignoring time (HH:mm:ss...) data', () => {
+  it('returns a formatted date string for a date object ignoring days and months, as well as time (HH:mm:ss...) data', () => {
     const date = new Date(2023, 11, 31, 23, 59, 59);
     const result = transformDateToString(date);
     expect(result).toBe('2023');

--- a/src/app/shared/utils/date-transformation.utils.spec.ts
+++ b/src/app/shared/utils/date-transformation.utils.spec.ts
@@ -2,26 +2,36 @@ import {transformDateToString, transformStringToDate} from './date-transformatio
 
 describe('transformDateToString', () => {
   it('returns a formatted date string for a valid date object', () => {
-    const date = new Date(2023, 0, 1);
+    const date = new Date(2010, 0, 1);
     const result = transformDateToString(date);
-    expect(result).toBe('20230101');
+    expect(result).toBe('2010');
   });
 
   it('returns a formatted date string for a date object ignoring time (HH:mm:ss...) data', () => {
     const date = new Date(2023, 11, 31, 23, 59, 59);
     const result = transformDateToString(date);
-    expect(result).toBe('20231231');
+    expect(result).toBe('2023');
   });
 });
 
 describe('transformStringToDate', () => {
-  it('returns a date object for a string in the format YYYYMMDD', () => {
-    const result = transformStringToDate('20231231');
-    expect(result).toEqual(new Date(2023, 11, 31));
+  it('should return a date object for a string in the format YYYY', () => {
+    const result = transformStringToDate('2010');
+    expect(result).toEqual(new Date('2010'));
   });
 
-  it('returns undefined for an undefined input', () => {
+  it('should return undefined for an undefined input', () => {
     const result = transformStringToDate(undefined);
+    expect(result).toBeUndefined();
+  });
+
+  it('should return undefined if the input string is too short', () => {
+    const result = transformStringToDate('123');
+    expect(result).toBeUndefined();
+  });
+
+  it('should return undefined if the input string is not a number', () => {
+    const result = transformStringToDate('asdf');
     expect(result).toBeUndefined();
   });
 });

--- a/src/app/shared/utils/date-transformation.utils.ts
+++ b/src/app/shared/utils/date-transformation.utils.ts
@@ -3,26 +3,21 @@
  */
 export function transformDateToString(date: Date): string {
   const year = date.getFullYear();
-  const month = String(date.getMonth() + 1).padStart(2, '0'); // months are 0-indexed
-  const day = String(date.getDate()).padStart(2, '0');
-  return `${year}${month}${day}`;
+  return `${year}`;
 }
 
 /**
  * Transforms a string in the format 'YYYYMMDD' into a date object; returns undefined if the input is either undefined or incorrectly formatted.
  */
 export function transformStringToDate(date: string | undefined): Date | undefined {
-  if (!date || date.length < 8) {
+  if (!date || date.length < 4) {
     return undefined;
   }
   const year = Number(date.substring(0, 4));
-  const month = Number(date.substring(4, 6));
-  const day = Number(date.substring(6, 8));
 
-  if (Number.isNaN(year) || Number.isNaN(month) || Number.isNaN(day)) {
+  if (Number.isNaN(year)) {
     return undefined;
   }
 
-  // Note: months are 0-indexed in JavaScript Date objects
-  return new Date(year, month - 1, day);
+  return new Date(date);
 }

--- a/src/app/shared/utils/date-transformation.utils.ts
+++ b/src/app/shared/utils/date-transformation.utils.ts
@@ -1,5 +1,5 @@
 /**
- * Transforms a date object into a string in the format 'YYYYMMDD'.
+ * Transforms a date object into a string in the format 'YYYY'.
  */
 export function transformDateToString(date: Date): string {
   const year = date.getFullYear();
@@ -7,7 +7,7 @@ export function transformDateToString(date: Date): string {
 }
 
 /**
- * Transforms a string in the format 'YYYYMMDD' into a date object; returns undefined if the input is either undefined or incorrectly formatted.
+ * Transforms a string in the format 'YYYY' into a date object; returns undefined if the input is either undefined or incorrectly formatted.
  */
 export function transformStringToDate(date: string | undefined): Date | undefined {
   if (!date || date.length < 4) {

--- a/src/app/stac/service/asset.service.spec.ts
+++ b/src/app/stac/service/asset.service.spec.ts
@@ -96,9 +96,9 @@ describe('AssetService', () => {
       const collection = 'collection';
       const stationId = 'stationId';
       stacApiService.getAssets.and.resolveTo([
-        {filename: `${collection}_${stationId}_t_historical_19910101_20001231.csv`, url: 'www.meteoschweiz.admin.ch'},
-        {filename: `${collection}_${stationId}_t_historical_20010101_20101231.csv`, url: 'www.meteoschweiz.admin.ch'},
-        {filename: `${collection}_${stationId}_t_historical_20110101_20201231.csv`, url: 'www.meteoschweiz.admin.ch'},
+        {filename: `${collection}_${stationId}_t_historical_1991-2000.csv`, url: 'www.meteoschweiz.admin.ch'},
+        {filename: `${collection}_${stationId}_t_historical_2001-2010.csv`, url: 'www.meteoschweiz.admin.ch'},
+        {filename: `${collection}_${stationId}_t_historical_2011-2020.csv`, url: 'www.meteoschweiz.admin.ch'},
       ]);
 
       const result = await service.loadStationAssets(collection, stationId);
@@ -106,44 +106,26 @@ describe('AssetService', () => {
       expect(result).toEqual(
         jasmine.arrayWithExactContents([
           {
-            filename: `${collection}_${stationId}_t_historical_19910101_20001231.csv`,
+            filename: `${collection}_${stationId}_t_historical_1991-2000.csv`,
             url: 'www.meteoschweiz.admin.ch',
             interval: 'ten-minutes',
             timeRange: 'historical',
             dateRange: {start: jasmine.any(Date), end: jasmine.any(Date)},
           },
           {
-            filename: `${collection}_${stationId}_t_historical_20010101_20101231.csv`,
+            filename: `${collection}_${stationId}_t_historical_2001-2010.csv`,
             url: 'www.meteoschweiz.admin.ch',
             interval: 'ten-minutes',
             timeRange: 'historical',
             dateRange: {start: jasmine.any(Date), end: jasmine.any(Date)},
           },
           {
-            filename: `${collection}_${stationId}_t_historical_20110101_20201231.csv`,
+            filename: `${collection}_${stationId}_t_historical_2011-2020.csv`,
             url: 'www.meteoschweiz.admin.ch',
             interval: 'ten-minutes',
             timeRange: 'historical',
             dateRange: {start: jasmine.any(Date), end: jasmine.any(Date)},
           },
-        ]),
-      );
-    });
-
-    it('should parse dates correctly', async () => {
-      const collection = 'collection';
-      const stationId = 'stationId';
-      stacApiService.getAssets.and.resolveTo([
-        {filename: `${collection}_${stationId}_t_historical_19910101_20001231.csv`, url: 'www.meteoschweiz.admin.ch'},
-      ]);
-
-      const result = await service.loadStationAssets(collection, stationId);
-
-      expect(result).toEqual(
-        jasmine.arrayWithExactContents([
-          jasmine.objectContaining({
-            dateRange: {start: new Date('1991-01-01T00:00'), end: new Date('2000-12-31T00:00')},
-          }),
         ]),
       );
     });

--- a/src/app/stac/service/asset.service.ts
+++ b/src/app/stac/service/asset.service.ts
@@ -18,7 +18,7 @@ export class AssetService {
   private readonly errorHandler = inject(ErrorHandler);
 
   private readonly stationParseRegex =
-    /^(?<collectionId>[^_]+)_(?<stationId>[^_]+)_(?<interval>[^_]+)(?:_(?<timeRange>[^_]+)(?:_(?<fromDate>\d{8})_(?<toDate>\d{8}))?)?\.csv$/;
+    /^(?<collectionId>[^_]+)_(?<stationId>[^_]+)_(?<interval>[^_]+)(?:_(?<timeRange>[^_]+)(?:_(?<fromDate>\d{4})-(?<toDate>\d{4}))?)?\.csv$/;
 
   public async loadCollectionAssets(collections: string[]): Promise<CollectionAsset[]> {
     const assets = await Promise.all(


### PR DESCRIPTION
The format for historical date ranges was changed to `YYYY-YYYY` in the csv filename. For this the parsing had to be adjusted.

We opted to keep the date objects in place. There is a chance that month and day will be reintroduced at a later stage so we want to keep the option for that.

Some tests were changed to not test for correct date transformation anymore. These tests test functions which rely on functions from `date-transformation.utils.ts`. These functions are already tested and test that transforming string to date and back works. This means that there is no need to test this again in the other tests and can be assumed working. This reduces the number of test that need to be adjusted when the format next changes.