### PR TITLE
Stepper styling #87

### DIFF
--- a/src/app/data-selection-form/components/step-label/step-label.component.html
+++ b/src/app/data-selection-form/components/step-label/step-label.component.html
@@ -1,0 +1,15 @@
+<div class="step-label">
+  @if (currentValue()) {
+    <span>{{ title() }}: {{ currentValue() }}</span>
+  } @else {
+    <span>{{ title() }}</span>
+  }
+  @if (description()) {
+    <span>
+      <small>{{ description() }}</small>
+      @if (descriptionInfoTooltip()) {
+        <mat-icon class="step-label__tooltip-icon" [matTooltip]="descriptionInfoTooltip()">info_outline</mat-icon>
+      }
+    </span>
+  }
+</div>

--- a/src/app/data-selection-form/components/step-label/step-label.component.scss
+++ b/src/app/data-selection-form/components/step-label/step-label.component.scss
@@ -1,0 +1,11 @@
+@use 'material-mixins' as mat-mixins;
+
+.step-label {
+  display: flex;
+  flex-direction: column;
+  font-size: 18px;
+
+  &__tooltip-icon {
+    @include mat-mixins.mat-icon-override-size(0.75rem);
+  }
+}

--- a/src/app/data-selection-form/components/step-label/step-label.component.ts
+++ b/src/app/data-selection-form/components/step-label/step-label.component.ts
@@ -1,0 +1,16 @@
+import {Component, input} from '@angular/core';
+import {MatIcon} from '@angular/material/icon';
+import {MatTooltip} from '@angular/material/tooltip';
+
+@Component({
+  selector: 'app-step-label',
+  imports: [MatIcon, MatTooltip],
+  templateUrl: './step-label.component.html',
+  styleUrl: './step-label.component.scss',
+})
+export class StepLabelComponent {
+  public readonly title = input.required<string>();
+  public readonly description = input<string>();
+  public readonly descriptionInfoTooltip = input<string>();
+  public readonly currentValue = input<string | null>();
+}

--- a/src/app/data-selection-form/data-selection-form.component.html
+++ b/src/app/data-selection-form/data-selection-form.component.html
@@ -4,9 +4,14 @@
     <ng-template matStepperIcon="edit">
       <mat-icon>check</mat-icon>
     </ng-template>
-    <mat-step [completed]="(selectedCollection$ | async) !== null">
+    @let selectedCollection = selectedCollection$ | async;
+    <mat-step [completed]="selectedCollection !== null">
       <ng-template matStepLabel>
-        {{ t('form.stepper.station.label') }}<br /><small>{{ t('form.stepper.station.label.explanation') }}</small>
+        <app-step-label
+          [title]="t('form.stepper.station.label')"
+          [description]="t('form.stepper.station.label.explanation')"
+          [currentValue]="(selectedStationForCollection$ | async)?.displayName"
+        ></app-step-label>
       </ng-template>
       <app-station-selection-step></app-station-selection-step>
       <div class="data-selection-form__stepper__step-control">
@@ -20,12 +25,15 @@
         </button>
       </div>
     </mat-step>
-    <mat-step [completed]="(selectedSelectedDataInterval$ | async) !== null">
+    @let selectedSelectedDataInterval = selectedSelectedDataInterval$ | async;
+    <mat-step [completed]="selectedSelectedDataInterval !== null">
       <ng-template matStepLabel>
-        {{ t('form.stepper.interval.label') }}<br /><small>{{ t('form.stepper.interval.label.explanation') }}</small>
-        <mat-icon class="data-selection-form__stepper__tooltip-icon" [matTooltip]="t('form.stepper.interval.label.tooltip')"
-          >info_outline</mat-icon
-        >
+        <app-step-label
+          [title]="t('form.stepper.interval.label')"
+          [description]="t('form.stepper.interval.label.explanation')"
+          [descriptionInfoTooltip]="t('form.stepper.interval.label.tooltip')"
+          [currentValue]="selectedSelectedDataInterval ? t('form.interval.' + selectedSelectedDataInterval) : undefined"
+        ></app-step-label>
       </ng-template>
       <app-interval-selection></app-interval-selection>
       <div class="data-selection-form__stepper__step-control">
@@ -42,8 +50,14 @@
         </button>
       </div>
     </mat-step>
-    <mat-step [completed]="(selectedSelectedTimeRange$ | async) !== null">
-      <ng-template matStepLabel>{{ t('form.stepper.time-range.label') }}</ng-template>
+    @let selectedSelectedTimeRange = selectedSelectedTimeRange$ | async;
+    <mat-step [completed]="selectedSelectedTimeRange !== null">
+      <ng-template matStepLabel>
+        <app-step-label
+          [title]="t('form.stepper.time-range.label')"
+          [currentValue]="selectedSelectedTimeRange ? t('form.time-range.' + selectedSelectedTimeRange) : undefined"
+        ></app-step-label>
+      </ng-template>
       <app-time-range-selection></app-time-range-selection>
       <div class="data-selection-form__stepper__step-control">
         <button class="data-selection-form__stepper__step-control__back-button" mat-flat-button matStepperPrevious>
@@ -59,12 +73,8 @@
         </button>
       </div>
     </mat-step>
-    <mat-step [completed]="(selectedSelectedTimeRange$ | async) !== null">
-      <ng-template matStepLabel
-        >{{ t('form.stepper.selection-review.label') }}<br /><small>{{
-          t('form.stepper.selection-review.label.explanation')
-        }}</small></ng-template
-      >
+    <mat-step [completed]="selectedSelectedTimeRange !== null">
+      <ng-template matStepLabel><app-step-label [title]="t('form.stepper.selection-review.label')"></app-step-label></ng-template>
       <app-selection-review></app-selection-review>
       <div class="data-selection-form__stepper__step-control">
         <button class="data-selection-form__stepper__step-control__back-button" mat-flat-button matStepperPrevious>
@@ -75,9 +85,9 @@
         </button>
       </div>
     </mat-step>
-    <mat-step [completed]="(selectedSelectedTimeRange$ | async) !== null">
-      <ng-template matStepLabel>{{ t('form.stepper.download.label') }}</ng-template>
-      <app-download-asset> </app-download-asset>
+    <mat-step [completed]="selectedSelectedTimeRange !== null">
+      <ng-template matStepLabel><app-step-label [title]="t('form.stepper.download.label')"></app-step-label></ng-template>
+      <app-download-asset></app-download-asset>
     </mat-step>
   </mat-vertical-stepper>
 </div>

--- a/src/app/data-selection-form/data-selection-form.component.html
+++ b/src/app/data-selection-form/data-selection-form.component.html
@@ -1,6 +1,6 @@
 <div class="data-selection-form" *transloco="let t">
   <app-measurement-data-type-selection></app-measurement-data-type-selection>
-  <mat-vertical-stepper class="data-selection-form__stepper" [linear]="true" #stepper>
+  <mat-vertical-stepper class="data-selection-form__stepper" [linear]="true">
     <ng-template matStepperIcon="edit">
       <mat-icon>check</mat-icon>
     </ng-template>
@@ -28,6 +28,7 @@
     @let selectedSelectedDataInterval = selectedSelectedDataInterval$ | async;
     <mat-step [completed]="selectedSelectedDataInterval !== null">
       <ng-template matStepLabel>
+        <!-- t(form.interval.ten-minutes, form.interval.hourly, form.interval.daily, form.interval.monthly, form.interval.yearly) -->
         <app-step-label
           [title]="t('form.stepper.interval.label')"
           [description]="t('form.stepper.interval.label.explanation')"
@@ -53,6 +54,7 @@
     @let selectedSelectedTimeRange = selectedSelectedTimeRange$ | async;
     <mat-step [completed]="selectedSelectedTimeRange !== null">
       <ng-template matStepLabel>
+        <!-- t(form.time-range.now, form.time-range.recent, form.time-range.historical) -->
         <app-step-label
           [title]="t('form.stepper.time-range.label')"
           [currentValue]="selectedSelectedTimeRange ? t('form.time-range.' + selectedSelectedTimeRange) : undefined"

--- a/src/app/data-selection-form/data-selection-form.component.html
+++ b/src/app/data-selection-form/data-selection-form.component.html
@@ -76,7 +76,12 @@
       </div>
     </mat-step>
     <mat-step [completed]="selectedSelectedTimeRange !== null">
-      <ng-template matStepLabel><app-step-label [title]="t('form.stepper.selection-review.label')"></app-step-label></ng-template>
+      <ng-template matStepLabel>
+        <app-step-label
+          [title]="t('form.stepper.selection-review.label')"
+          [description]="t('form.stepper.selection-review.label.explanation')"
+        ></app-step-label>
+      </ng-template>
       <app-selection-review></app-selection-review>
       <div class="data-selection-form__stepper__step-control">
         <button class="data-selection-form__stepper__step-control__back-button" mat-flat-button matStepperPrevious>

--- a/src/app/data-selection-form/data-selection-form.component.html
+++ b/src/app/data-selection-form/data-selection-form.component.html
@@ -1,6 +1,9 @@
 <div class="data-selection-form" *transloco="let t">
   <app-measurement-data-type-selection></app-measurement-data-type-selection>
   <mat-vertical-stepper class="data-selection-form__stepper" [linear]="true" #stepper>
+    <ng-template matStepperIcon="edit">
+      <mat-icon>check</mat-icon>
+    </ng-template>
     <mat-step [completed]="(selectedCollection$ | async) !== null">
       <ng-template matStepLabel>
         {{ t('form.stepper.station.label') }}<br /><small>{{ t('form.stepper.station.label.explanation') }}</small>

--- a/src/app/data-selection-form/data-selection-form.component.html
+++ b/src/app/data-selection-form/data-selection-form.component.html
@@ -6,8 +6,13 @@
         {{ t('form.stepper.station.label') }}<br /><small>{{ t('form.stepper.station.label.explanation') }}</small>
       </ng-template>
       <app-station-selection-step></app-station-selection-step>
-      <div>
-        <button mat-button matStepperNext type="button" [disabled]="(selectedCollection$ | async) === null">
+      <div class="data-selection-form__stepper__step-control">
+        <button
+          class="data-selection-form__stepper__step-control__next-button"
+          mat-flat-button
+          matStepperNext
+          [disabled]="(selectedCollection$ | async) === null"
+        >
           {{ t('form.stepper.next') }}
         </button>
       </div>
@@ -20,9 +25,16 @@
         >
       </ng-template>
       <app-interval-selection></app-interval-selection>
-      <div>
-        <button mat-button matStepperPrevious type="button">{{ t('form.stepper.back') }}</button>
-        <button mat-button matStepperNext type="button" [disabled]="(selectedSelectedDataInterval$ | async) === null">
+      <div class="data-selection-form__stepper__step-control">
+        <button class="data-selection-form__stepper__step-control__back-button" mat-flat-button matStepperPrevious>
+          {{ t('form.stepper.back') }}
+        </button>
+        <button
+          class="data-selection-form__stepper__step-control__next-button"
+          mat-flat-button
+          matStepperNext
+          [disabled]="(selectedSelectedDataInterval$ | async) === null"
+        >
           {{ t('form.stepper.next') }}
         </button>
       </div>
@@ -30,9 +42,16 @@
     <mat-step [completed]="(selectedSelectedTimeRange$ | async) !== null">
       <ng-template matStepLabel>{{ t('form.stepper.time-range.label') }}</ng-template>
       <app-time-range-selection></app-time-range-selection>
-      <div>
-        <button mat-button matStepperPrevious type="button">{{ t('form.stepper.back') }}</button>
-        <button mat-button matStepperNext type="button" [disabled]="(selectedSelectedTimeRange$ | async) === null">
+      <div class="data-selection-form__stepper__step-control">
+        <button class="data-selection-form__stepper__step-control__back-button" mat-flat-button matStepperPrevious>
+          {{ t('form.stepper.back') }}
+        </button>
+        <button
+          class="data-selection-form__stepper__step-control__next-button"
+          mat-flat-button
+          matStepperNext
+          [disabled]="(selectedSelectedTimeRange$ | async) === null"
+        >
           {{ t('form.stepper.next') }}
         </button>
       </div>
@@ -44,9 +63,13 @@
         }}</small></ng-template
       >
       <app-selection-review></app-selection-review>
-      <div>
-        <button mat-button matStepperPrevious type="button">{{ t('form.stepper.back') }}</button>
-        <button mat-button matStepperNext type="button">{{ t('form.stepper.next') }}</button>
+      <div class="data-selection-form__stepper__step-control">
+        <button class="data-selection-form__stepper__step-control__back-button" mat-flat-button matStepperPrevious>
+          {{ t('form.stepper.back') }}
+        </button>
+        <button class="data-selection-form__stepper__step-control__next-button" mat-flat-button matStepperNext>
+          {{ t('form.stepper.next') }}
+        </button>
       </div>
     </mat-step>
     <mat-step [completed]="(selectedSelectedTimeRange$ | async) !== null">

--- a/src/app/data-selection-form/data-selection-form.component.scss
+++ b/src/app/data-selection-form/data-selection-form.component.scss
@@ -1,5 +1,6 @@
 @use 'material-mixins' as mat-mixins;
 @use 'design-variables' as variables;
+@use '@angular/material' as mat;
 
 .data-selection-form {
   width: 100%;
@@ -10,6 +11,36 @@
 
     &__tooltip-icon {
       @include mat-mixins.mat-icon-override-size(0.75rem);
+    }
+
+    &__step-control {
+      padding-top: 20px;
+
+      &__next-button,
+      &__back-button {
+        @include mat.button-overrides(
+          (
+            filled-container-shape: 0,
+            filled-label-text-color: variables.$white,
+          )
+        );
+      }
+
+      &__next-button {
+        @include mat.button-overrides(
+          (
+            filled-container-color: variables.$warn-red,
+          )
+        );
+      }
+
+      &__back-button {
+        @include mat.button-overrides(
+          (
+            filled-container-color: variables.$accent-grey,
+          )
+        );
+      }
     }
   }
 }

--- a/src/app/data-selection-form/data-selection-form.component.scss
+++ b/src/app/data-selection-form/data-selection-form.component.scss
@@ -6,8 +6,18 @@
   width: 100%;
 
   &__stepper {
+    padding-top: 40px;
     background-color: variables.$background-color;
     color: variables.$white;
+
+    @include mat.stepper-overrides(
+      (
+        header-selected-state-icon-foreground-color: variables.$white,
+        header-selected-state-icon-background-color: variables.$warn-red,
+        header-edit-state-icon-foreground-color: variables.$white,
+        header-edit-state-icon-background-color: variables.$warn-red,
+      )
+    );
 
     &__tooltip-icon {
       @include mat-mixins.mat-icon-override-size(0.75rem);

--- a/src/app/data-selection-form/data-selection-form.component.scss
+++ b/src/app/data-selection-form/data-selection-form.component.scss
@@ -1,10 +1,7 @@
-@use 'material-mixins' as mat-mixins;
 @use 'design-variables' as variables;
 @use '@angular/material' as mat;
 
 .data-selection-form {
-  width: 100%;
-
   &__stepper {
     padding-top: 40px;
     background-color: variables.$background-color;
@@ -18,10 +15,6 @@
         header-edit-state-icon-background-color: variables.$warn-red,
       )
     );
-
-    &__tooltip-icon {
-      @include mat-mixins.mat-icon-override-size(0.75rem);
-    }
 
     &__step-control {
       padding-top: 20px;

--- a/src/app/data-selection-form/data-selection-form.component.ts
+++ b/src/app/data-selection-form/data-selection-form.component.ts
@@ -3,16 +3,17 @@ import {AfterViewInit, Component, inject, OnDestroy, ViewChild} from '@angular/c
 import {MatButton} from '@angular/material/button';
 import {MatIcon} from '@angular/material/icon';
 import {MatStepper, MatStepperModule} from '@angular/material/stepper';
-import {MatTooltip} from '@angular/material/tooltip';
 import {TranslocoModule} from '@jsverse/transloco';
 import {Store} from '@ngrx/store';
 import {debounceTime, Subscription, tap} from 'rxjs';
 import {formFeature} from '../state/form/reducers/form.reducer';
+import {selectSelectedStationForCollection} from '../state/form/selectors/form.selector';
 import {DownloadAssetComponent} from './components/download-asset/download-asset.component';
 import {IntervalSelectionComponent} from './components/interval-selection/interval-selection.component';
 import {MeasurementDataTypeSelectionComponent} from './components/measurement-data-type-selection/measurement-data-type-selection.component';
 import {SelectionReviewComponent} from './components/selection-review/selection-review.component';
 import {StationSelectionStepComponent} from './components/station-selection-step/station-selection-step.component';
+import {StepLabelComponent} from './components/step-label/step-label.component';
 import {TimeRangeSelectionComponent} from './components/time-range-selection/time-range-selection.component';
 import {dataSelectionFormConstants} from './constants/data-selection-form.constant';
 import type {FormStep} from '../shared/constants/form-step.constant';
@@ -30,8 +31,8 @@ import type {FormStep} from '../shared/constants/form-step.constant';
     AsyncPipe,
     StationSelectionStepComponent,
     MeasurementDataTypeSelectionComponent,
+    StepLabelComponent,
     MatIcon,
-    MatTooltip,
   ],
   templateUrl: './data-selection-form.component.html',
   styleUrl: './data-selection-form.component.scss',
@@ -40,6 +41,7 @@ export class DataSelectionFormComponent implements AfterViewInit, OnDestroy {
   private readonly store = inject(Store);
 
   @ViewChild(MatStepper) private readonly stepper: MatStepper | undefined;
+  protected readonly selectedStationForCollection$ = this.store.select(selectSelectedStationForCollection);
   protected readonly selectedSelectedDataInterval$ = this.store.select(formFeature.selectSelectedDataInterval);
   protected readonly selectedSelectedTimeRange$ = this.store.select(formFeature.selectSelectedTimeRange);
   protected readonly selectedCollection$ = this.store.select(formFeature.selectSelectedCollection);


### PR DESCRIPTION
There are multiple changes - all targeting the stepper.
* [Styling step control buttons #94](https://github.com/MeteoSwiss/opendata-explorer/issues/94)
* [General color styling #87](https://github.com/MeteoSwiss/opendata-explorer/issues/87)
The stepper is now using red as primary color; this is shown in the next button as well as the current or completed step icon. Also the icon for completed steps is a check ✅
* [Steps show the currently selected value #89](https://github.com/MeteoSwiss/opendata-explorer/issues/89)
The new `step-label.component` contains all logic to display the current step label. Currently, this means that the title can be followed by the selected value for all steps that have a selectable value. Also it's possible to show a description. And as a special case: The description can also contain an info tooltip icon with even more description text.