### PR TITLE
Various design stylings

### DIFF
--- a/public/i18n/de.json
+++ b/public/i18n/de.json
@@ -58,7 +58,7 @@
   "form.download.stations-explanation": "Liste aller Stationsabkürzungen mit Namen, Kanton, Wigos ID, Stationstyp, Höhe, Koordinaten, Ausrichtung und URL der Stationsdetailseiten",
   "form.download.inventory-explanation": "Liste aller Stationen und Parameter mit Start- und Enddatum der Messungen",
   "form.download.copy-url": "Permanenten Download-Link kopieren",
-  "form.download.copy-url.tooltip": "Missing value for 'form.download.copy-url.tooltip'",
+  "form.download.copy-url.tooltip": "In die Zwischenablage kopieren",
   "form.download.download-programmatically-info": "Informationen, wie Sie Daten automatisch beziehen können",
   "form.download.download-programmatically-info.url": "https://opendatadocs.meteoswiss.ch/de/general/download",
   "form.collection-selection.title": "Messnetz wählen",

--- a/public/i18n/de.json
+++ b/public/i18n/de.json
@@ -58,6 +58,7 @@
   "form.download.stations-explanation": "Liste aller Stationsabkürzungen mit Namen, Kanton, Wigos ID, Stationstyp, Höhe, Koordinaten, Ausrichtung und URL der Stationsdetailseiten",
   "form.download.inventory-explanation": "Liste aller Stationen und Parameter mit Start- und Enddatum der Messungen",
   "form.download.copy-url": "Permanenten Download-Link kopieren",
+  "form.download.copy-url.tooltip": "Missing value for 'form.download.copy-url.tooltip'",
   "form.download.download-programmatically-info": "Informationen, wie Sie Daten automatisch beziehen können",
   "form.download.download-programmatically-info.url": "https://opendatadocs.meteoswiss.ch/de/general/download",
   "form.collection-selection.title": "Messnetz wählen",

--- a/public/i18n/en.json
+++ b/public/i18n/en.json
@@ -58,6 +58,7 @@
   "form.download.stations-explanation": "List of all station abbreviations with name, canton, Wigos ID, station type, altitude, coordinates, orientation and URL of the station details pages",
   "form.download.inventory-explanation": "List of all stations and parameters with start and end date of the measurements",
   "form.download.copy-url": "Copy permanent download link",
+  "form.download.copy-url.tooltip": "Copy to clipboard",
   "form.download.download-programmatically-info": "Information on how you can obtain data automatically",
   "form.download.download-programmatically-info.url": "https://opendatadocs.meteoswiss.ch/general/download",
   "form.collection-selection.title": "Select measuring network",

--- a/public/i18n/fr.json
+++ b/public/i18n/fr.json
@@ -58,6 +58,7 @@
   "form.download.stations-explanation": "Liste de toutes les abréviations des stations avec nom, canton, Wigos ID, type de station, altitude, coordonnées, orientation et URL de la page de détail des stations",
   "form.download.inventory-explanation": "Liste de toutes les stations et de tous les paramètres avec les dates de début et de fin des mesures",
   "form.download.copy-url": "Copier le lien de téléchargement permanent",
+  "form.download.copy-url.tooltip": "Copier dans le presse-papiers",
   "form.download.download-programmatically-info": "Informations sur la manière d’obtenir des données",
   "form.download.download-programmatically-info.url": "https://opendatadocs.meteoswiss.ch/fr/general/download",
   "form.collection-selection.title": "Sélectionner le réseau de mesure",

--- a/public/i18n/it.json
+++ b/public/i18n/it.json
@@ -58,6 +58,7 @@
   "form.download.stations-explanation": "Elenco di tutte le abbreviazioni delle stazioni con nome, cantone, Wigos ID, tipo di stazione, altitudine, coordinate, orientamento e URL della pagina dei dettagli delle stazioni",
   "form.download.inventory-explanation": "Elenco di tutte le stazioni e dei parametri con la data di inizio e di fine delle misurazioni",
   "form.download.copy-url": "Copiare il link permanente per il download",
+  "form.download.copy-url.tooltip": "Copia negli appunti",
   "form.download.download-programmatically-info": "Informazioni su come ottenere i dati automaticamente",
   "form.download.download-programmatically-info.url": "https://opendatadocs.meteoswiss.ch/it/general/download",
   "form.collection-selection.title": "Selezionare la rete di misura",

--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -1,5 +1,5 @@
 .main {
   height: 100%;
-  max-width: 1620px;
+  max-width: 1223px;
   margin: 20px;
 }

--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -1,5 +1,5 @@
 .main {
   height: 100%;
-  max-width: 1223px;
+  max-width: 1240px;
   margin: 20px;
 }

--- a/src/app/data-selection-form/components/collection-selection/collection-selection.component.scss
+++ b/src/app/data-selection-form/components/collection-selection/collection-selection.component.scss
@@ -29,6 +29,7 @@
             selected-icon-color: variables.$foreground-color,
             unselected-icon-color: variables.$foreground-color,
             label-text-color: variables.$foreground-color,
+            label-text-size: 18px,
           )
         );
       }

--- a/src/app/data-selection-form/components/download-asset/download-asset.component.html
+++ b/src/app/data-selection-form/components/download-asset/download-asset.component.html
@@ -39,9 +39,7 @@
           <mat-icon>content_copy</mat-icon>
         </button>
       </div>
-      <p class="download-asset__explanation">
-        <a [href]="t('form.download.download-programmatically-info.url')">{{ t('form.download.download-programmatically-info') }}</a>
-      </p>
+      <a [href]="t('form.download.download-programmatically-info.url')">{{ t('form.download.download-programmatically-info') }}</a>
     </div>
   }
 </div>

--- a/src/app/data-selection-form/components/download-asset/download-asset.component.html
+++ b/src/app/data-selection-form/components/download-asset/download-asset.component.html
@@ -35,7 +35,12 @@
         <mat-form-field appearance="fill" class="download-asset__section__copy-link__link-url">
           <input matInput type="text" [value]="asset.url" readonly />
         </mat-form-field>
-        <button class="download-asset__section__copy-link__copy-button" mat-mini-fab [cdkCopyToClipboard]="asset.url">
+        <button
+          class="download-asset__section__copy-link__copy-button"
+          mat-mini-fab
+          [cdkCopyToClipboard]="asset.url"
+          [matTooltip]="t('form.download.copy-url.tooltip')"
+        >
           <mat-icon>content_copy</mat-icon>
         </button>
       </div>

--- a/src/app/data-selection-form/components/download-asset/download-asset.component.scss
+++ b/src/app/data-selection-form/components/download-asset/download-asset.component.scss
@@ -7,6 +7,7 @@
   display: flex;
   gap: 25px;
   flex-direction: column;
+  font-size: 18px;
 
   &__section {
     display: flex;

--- a/src/app/data-selection-form/components/download-asset/download-asset.component.ts
+++ b/src/app/data-selection-form/components/download-asset/download-asset.component.ts
@@ -4,6 +4,7 @@ import {Component, inject} from '@angular/core';
 import {MatMiniFabButton} from '@angular/material/button';
 import {MatIcon} from '@angular/material/icon';
 import {MatFormField, MatInput} from '@angular/material/input';
+import {MatTooltip} from '@angular/material/tooltip';
 import {TranslocoModule} from '@jsverse/transloco';
 import {Store} from '@ngrx/store';
 import {selectSelectedAsset} from '../../../state/assets/selectors/asset.selectors';
@@ -12,7 +13,17 @@ import {DownloadAssetLinkComponent} from '../download-asset-link/download-asset-
 
 @Component({
   selector: 'app-download-asset',
-  imports: [TranslocoModule, AsyncPipe, DownloadAssetLinkComponent, MatInput, MatFormField, MatIcon, MatMiniFabButton, ClipboardModule],
+  imports: [
+    TranslocoModule,
+    AsyncPipe,
+    DownloadAssetLinkComponent,
+    MatInput,
+    MatFormField,
+    MatIcon,
+    MatMiniFabButton,
+    ClipboardModule,
+    MatTooltip,
+  ],
   templateUrl: './download-asset.component.html',
   styleUrl: './download-asset.component.scss',
 })

--- a/src/app/data-selection-form/components/measurement-data-type-selection/measurement-data-type-selection.component.html
+++ b/src/app/data-selection-form/components/measurement-data-type-selection/measurement-data-type-selection.component.html
@@ -16,11 +16,15 @@
       @switch (measurementDataType) {
         @case ('normal') {
           <span>{{ t('form.measurement-data-type.normal.explanation') }}</span>
-          <a [href]="t('form.measurement-data-type.normal.info-url')">{{ t('form.measurement-data-type.more-info-link') }}</a>
+          <a class="measurement-data-type-selection__description__link" [href]="t('form.measurement-data-type.normal.info-url')">
+            {{ t('form.measurement-data-type.more-info-link') }}
+          </a>
         }
         @case ('homogenous') {
           <span>{{ t('form.measurement-data-type.homogenous.explanation') }}</span>
-          <a [href]="t('form.measurement-data-type.homogenous.info-url')">{{ t('form.measurement-data-type.more-info-link') }}</a>
+          <a class="measurement-data-type-selection__description__link" [href]="t('form.measurement-data-type.homogenous.info-url')">
+            {{ t('form.measurement-data-type.more-info-link') }}
+          </a>
         }
       }
     }

--- a/src/app/data-selection-form/components/measurement-data-type-selection/measurement-data-type-selection.component.scss
+++ b/src/app/data-selection-form/components/measurement-data-type-selection/measurement-data-type-selection.component.scss
@@ -13,8 +13,13 @@
         selected-state-text-color: variables.$white,
         text-color: variables.$white,
         label-text-weight: normal,
+        label-text-size: 18px,
       )
     );
+
+    mat-button-toggle {
+      padding: 10px;
+    }
   }
 
   &__description {
@@ -23,7 +28,12 @@
     gap: 5px;
     margin-top: 20px;
     background-color: var(--mat-sys-inverse-primary);
-    padding: 20px 12px;
+    padding: 20px;
     box-sizing: border-box;
+    font-size: 16px;
+
+    &__link {
+      margin-top: 10px;
+    }
   }
 }

--- a/src/app/data-selection-form/components/selection-review/selection-review.component.scss
+++ b/src/app/data-selection-form/components/selection-review/selection-review.component.scss
@@ -1,7 +1,8 @@
 .selection-review-row {
   line-height: 28px;
+  font-size: 18px;
 
   &__title {
-    font-weight: bold;
+    font-weight: 500;
   }
 }

--- a/src/app/data-selection-form/components/station-info/station-info.component.html
+++ b/src/app/data-selection-form/components/station-info/station-info.component.html
@@ -7,11 +7,15 @@
         {{ t('form.station.selection-info.more-info') }}
       </a>
     }
-    <h5 class="station-info__title">{{ t('form.collection-selection.parameter-groups') }}</h5>
+    <h5 class="station-info__parameter-title">{{ t('form.collection-selection.parameter-groups') }}</h5>
     <mat-list class="station-info__parameter-groups">
       @for (parameterGroup of station().parameterGroups; track parameterGroup.id) {
         <mat-list-item class="station-info__parameter-groups__item">
-          <mat-icon matListItemIcon [svgIcon]="parameterGroup.id | iconFromConfig"></mat-icon>
+          <mat-icon
+            class="station-info__parameter-groups__item__icon"
+            matListItemIcon
+            [svgIcon]="parameterGroup.id | iconFromConfig"
+          ></mat-icon>
           <div matListItemTitle>{{ parameterGroup.name | translatableString: currentLanguage }}</div>
         </mat-list-item>
       }

--- a/src/app/data-selection-form/components/station-info/station-info.component.scss
+++ b/src/app/data-selection-form/components/station-info/station-info.component.scss
@@ -1,15 +1,21 @@
+@use 'material-mixins' as mat-mixins;
 @use '@angular/material' as mat;
 
 .station-info {
   display: flex;
   flex-direction: column;
 
-  &__title {
-    font-size: unset;
-    margin: 0.5em 0;
+  &__title,
+  &__parameter-title {
+    margin-bottom: 0.5em;
+  }
+
+  &__parameter-title {
+    margin-top: 40px;
   }
 
   &__link {
+    margin-top: 10px;
     color: inherit;
   }
 
@@ -23,6 +29,11 @@
     &__item {
       padding: 0;
       align-items: center;
+      margin-bottom: 5px;
+
+      &__icon {
+        @include mat-mixins.mat-icon-override-size(48px);
+      }
     }
   }
 }

--- a/src/app/data-selection-form/components/time-range-selection/time-range-selection.component.html
+++ b/src/app/data-selection-form/components/time-range-selection/time-range-selection.component.html
@@ -12,10 +12,10 @@
     [matTooltip]="t('form.selection-not-available')"
     [matTooltipDisabled]="isNowInAvailableTimeRanges"
   >
-    <mat-radio-button value="now" [disabled]="!isNowInAvailableTimeRanges"
-      >{{ t('form.time-range.now') }}
+    <mat-radio-button value="now" [disabled]="!isNowInAvailableTimeRanges" [aria-label]="t('form.time-range.now')">
+      {{ t('form.time-range.now') }}
       <br />
-      <span class="time-range-selection__selection__explanation">{{ t('form.time-range.now.explanation') }}</span>
+      <small>{{ t('form.time-range.now.explanation') }}</small>
     </mat-radio-button>
   </div>
 
@@ -25,13 +25,19 @@
     [matTooltip]="t('form.selection-not-available')"
     [matTooltipDisabled]="isRecentInAvailableTimeRanges"
   >
-    <mat-radio-button value="recent" [disabled]="!isRecentInAvailableTimeRanges"
-      >{{ t('form.time-range.recent') }}
-      <mat-icon class="time-range-selection__selection__tooltip-icon" [matTooltip]="t('form.time-range.recent.tooltip')"
-        >info_outline</mat-icon
-      >
-      <br />
-      <span class="time-range-selection__selection__explanation">{{ t('form.time-range.recent.explanation') }}</span>
+    <mat-radio-button value="recent" [disabled]="!isRecentInAvailableTimeRanges" [aria-label]="t('form.time-range.recent')">
+      <div class="time-range-selection__selection__content">
+        <div class="time-range-selection__selection__content__label">
+          <span>{{ t('form.time-range.recent') }}</span>
+          <mat-icon
+            class="time-range-selection__selection__content__label__tooltip-icon"
+            [matTooltip]="t('form.time-range.recent.tooltip')"
+          >
+            info_outline
+          </mat-icon>
+        </div>
+        <small>{{ t('form.time-range.recent.explanation') }}</small>
+      </div>
     </mat-radio-button>
   </div>
 

--- a/src/app/data-selection-form/components/time-range-selection/time-range-selection.component.scss
+++ b/src/app/data-selection-form/components/time-range-selection/time-range-selection.component.scss
@@ -1,4 +1,5 @@
 @use 'material-mixins' as mat-mixins;
+@use '@angular/material' as mat;
 
 .time-range-selection {
   display: flex;
@@ -13,12 +14,20 @@
   &__selection {
     width: fit-content;
 
-    &__explanation {
-      font-size: 0.85em;
-    }
+    &__content {
+      display: flex;
+      flex-direction: column;
 
-    &__tooltip-icon {
-      @include mat-mixins.mat-icon-override-size(1rem);
+      &__label {
+        display: flex;
+        flex-direction: row;
+        gap: 8px;
+        align-items: center;
+
+        &__tooltip-icon {
+          @include mat-mixins.mat-icon-override-size(24px);
+        }
+      }
     }
   }
 

--- a/src/app/data-selection-form/data-selection-form.component.scss
+++ b/src/app/data-selection-form/data-selection-form.component.scss
@@ -2,6 +2,7 @@
 @use '@angular/material' as mat;
 
 .data-selection-form {
+  padding-bottom: 100px;
   &__stepper {
     padding-top: 40px;
     background-color: variables.$background-color;

--- a/src/app/map/components/map-container/map-container.component.scss
+++ b/src/app/map/components/map-container/map-container.component.scss
@@ -2,7 +2,7 @@
 
 .map-container {
   position: relative;
-  height: 600px;
+  height: 435px;
 
   &__map {
     height: 100%;

--- a/src/styles/_overrides.scss
+++ b/src/styles/_overrides.scss
@@ -17,6 +17,12 @@ a {
       container-shape: 0,
     )
   );
+
+  @include mat.radio-overrides(
+    (
+      label-text-size: 16px,
+    )
+  );
 }
 
 mat-tooltip-component .mat-mdc-tooltip-surface {

--- a/src/styles/_overrides.scss
+++ b/src/styles/_overrides.scss
@@ -23,3 +23,15 @@ mat-tooltip-component .mat-mdc-tooltip-surface {
   padding: 15px;
   max-width: 500px;
 }
+
+h4 {
+  font-size: 18px;
+  margin-top: 40px;
+  font-weight: 500;
+}
+
+h5 {
+  font-size: 18px;
+  margin-top: 20px;
+  font-weight: 500;
+}


### PR DESCRIPTION
This is a collection of very small changes in the UI from the design review.
* [Adjust max width to 1263px (excluding margin) #95](https://github.com/MeteoSwiss/opendata-explorer/issues/95)
* [Adjust max height of the map #96](https://github.com/MeteoSwiss/opendata-explorer/issues/96)
* [Style collection selection #105](https://github.com/MeteoSwiss/opendata-explorer/issues/105)
* [Styling measurement data type selection #107](https://github.com/MeteoSwiss/opendata-explorer/issues/107)
* [Adjust radio button label text size #108](https://github.com/MeteoSwiss/opendata-explorer/issues/108)
* [Adjust i-button size and position #109](https://github.com/MeteoSwiss/opendata-explorer/issues/109)
* [Styling review step #110](https://github.com/MeteoSwiss/opendata-explorer/issues/110)
* [Styling download step #111](https://github.com/MeteoSwiss/opendata-explorer/issues/111)
* [Add tooltip for copy to clipboard button #112](https://github.com/MeteoSwiss/opendata-explorer/issues/112)