### PR TITLE
Open link in new tab #119

### DIFF
--- a/src/app/data-selection-form/components/download-asset-link/download-asset-link.component.html
+++ b/src/app/data-selection-form/components/download-asset-link/download-asset-link.component.html
@@ -1,6 +1,4 @@
-<span class="download-asset-link"
-  ><span
-    ><a [href]="asset().url">{{ asset().filename }}</a> (CSV)</span
-  >
+<span class="download-asset-link">
+  <span><app-external-link [href]="asset().url" [text]="asset().filename"></app-external-link> (CSV)</span>
   <mat-icon>file_download</mat-icon>
 </span>

--- a/src/app/data-selection-form/components/download-asset-link/download-asset-link.component.ts
+++ b/src/app/data-selection-form/components/download-asset-link/download-asset-link.component.ts
@@ -1,11 +1,12 @@
 import {Component, input} from '@angular/core';
 import {MatIcon} from '@angular/material/icon';
+import {ExternalLinkComponent} from '../../../shared/components/external-link/external-link.component';
 import {CollectionAsset} from '../../../shared/models/collection-assets';
 import {StationAsset} from '../../../shared/models/station-assets';
 
 @Component({
   selector: 'app-download-asset-link',
-  imports: [MatIcon],
+  imports: [MatIcon, ExternalLinkComponent],
   templateUrl: './download-asset-link.component.html',
   styleUrl: './download-asset-link.component.scss',
 })

--- a/src/app/data-selection-form/components/download-asset/download-asset.component.html
+++ b/src/app/data-selection-form/components/download-asset/download-asset.component.html
@@ -3,7 +3,8 @@
     <div class="download-asset__section">
       <h4 class="download-asset__section__title">{{ t('form.download.data') }}</h4>
       <p>
-        {{ t('form.download.terms') }} <a [href]="t('form.download.terms.link')">{{ t('form.download.terms.link-name') }}</a>
+        {{ t('form.download.terms') }}
+        <app-external-link [href]="t('form.download.terms.link')" [text]="t('form.download.terms.link-name')"></app-external-link>
       </p>
       <div>
         <app-download-asset-link [asset]="asset" />
@@ -44,7 +45,10 @@
           <mat-icon>content_copy</mat-icon>
         </button>
       </div>
-      <a [href]="t('form.download.download-programmatically-info.url')">{{ t('form.download.download-programmatically-info') }}</a>
+      <app-external-link
+        [href]="t('form.download.download-programmatically-info.url')"
+        [text]="t('form.download.download-programmatically-info')"
+      ></app-external-link>
     </div>
   }
 </div>

--- a/src/app/data-selection-form/components/download-asset/download-asset.component.ts
+++ b/src/app/data-selection-form/components/download-asset/download-asset.component.ts
@@ -7,6 +7,7 @@ import {MatFormField, MatInput} from '@angular/material/input';
 import {MatTooltip} from '@angular/material/tooltip';
 import {TranslocoModule} from '@jsverse/transloco';
 import {Store} from '@ngrx/store';
+import {ExternalLinkComponent} from '../../../shared/components/external-link/external-link.component';
 import {selectSelectedAsset} from '../../../state/assets/selectors/asset.selectors';
 import {selectSelectedCollectionMetaAssets} from '../../../state/form/selectors/form.selector';
 import {DownloadAssetLinkComponent} from '../download-asset-link/download-asset-link.component';
@@ -23,6 +24,7 @@ import {DownloadAssetLinkComponent} from '../download-asset-link/download-asset-
     MatMiniFabButton,
     ClipboardModule,
     MatTooltip,
+    ExternalLinkComponent,
   ],
   templateUrl: './download-asset.component.html',
   styleUrl: './download-asset.component.scss',

--- a/src/app/data-selection-form/components/measurement-data-type-selection/measurement-data-type-selection.component.html
+++ b/src/app/data-selection-form/components/measurement-data-type-selection/measurement-data-type-selection.component.html
@@ -16,15 +16,21 @@
       @switch (measurementDataType) {
         @case ('normal') {
           <span>{{ t('form.measurement-data-type.normal.explanation') }}</span>
-          <a class="measurement-data-type-selection__description__link" [href]="t('form.measurement-data-type.normal.info-url')">
-            {{ t('form.measurement-data-type.more-info-link') }}
-          </a>
+          <app-external-link
+            class="measurement-data-type-selection__description__link"
+            [href]="t('form.measurement-data-type.normal.info-url')"
+            [text]="t('form.measurement-data-type.more-info-link')"
+          >
+          </app-external-link>
         }
         @case ('homogenous') {
           <span>{{ t('form.measurement-data-type.homogenous.explanation') }}</span>
-          <a class="measurement-data-type-selection__description__link" [href]="t('form.measurement-data-type.homogenous.info-url')">
-            {{ t('form.measurement-data-type.more-info-link') }}
-          </a>
+          <app-external-link
+            class="measurement-data-type-selection__description__link"
+            [href]="t('form.measurement-data-type.homogenous.info-url')"
+            [text]="t('form.measurement-data-type.more-info-link')"
+          >
+          </app-external-link>
         }
       }
     }

--- a/src/app/data-selection-form/components/measurement-data-type-selection/measurement-data-type-selection.component.ts
+++ b/src/app/data-selection-form/components/measurement-data-type-selection/measurement-data-type-selection.component.ts
@@ -5,13 +5,14 @@ import {MatStepperModule} from '@angular/material/stepper';
 import {TranslocoModule} from '@jsverse/transloco';
 import {marker} from '@jsverse/transloco-keys-manager/marker';
 import {Store} from '@ngrx/store';
+import {ExternalLinkComponent} from '../../../shared/components/external-link/external-link.component';
 import {MeasurementDataType, measurementDataTypes} from '../../../shared/models/measurement-data-type';
 import {formActions} from '../../../state/form/actions/form.actions';
 import {formFeature} from '../../../state/form/reducers/form.reducer';
 
 @Component({
   selector: 'app-measurement-data-type-selection',
-  imports: [TranslocoModule, MatButtonToggleGroup, MatButtonToggle, MatStepperModule, AsyncPipe],
+  imports: [TranslocoModule, MatButtonToggleGroup, MatButtonToggle, MatStepperModule, AsyncPipe, ExternalLinkComponent],
   templateUrl: './measurement-data-type-selection.component.html',
   styleUrl: './measurement-data-type-selection.component.scss',
 })

--- a/src/app/data-selection-form/components/station-info/station-info.component.html
+++ b/src/app/data-selection-form/components/station-info/station-info.component.html
@@ -3,9 +3,7 @@
     <h5 class="station-info__title">{{ station().displayName }}</h5>
     <span> {{ station().elevation }} {{ t('form.station.selection-info.elevation-unit') }} </span>
     @if (station().url | translatableString: currentLanguage; as url) {
-      <a class="station-info__link" [href]="url" rel="noopener noreferrer" target="_blank">
-        {{ t('form.station.selection-info.more-info') }}
-      </a>
+      <app-external-link class="station-info__link" [href]="url" [text]="t('form.station.selection-info.more-info')"></app-external-link>
     }
     <h5 class="station-info__parameter-title">{{ t('form.collection-selection.parameter-groups') }}</h5>
     <mat-list class="station-info__parameter-groups">

--- a/src/app/data-selection-form/components/station-info/station-info.component.ts
+++ b/src/app/data-selection-form/components/station-info/station-info.component.ts
@@ -4,6 +4,7 @@ import {MatIcon} from '@angular/material/icon';
 import {MatList, MatListItem} from '@angular/material/list';
 import {TranslocoDirective} from '@jsverse/transloco';
 import {Store} from '@ngrx/store';
+import {ExternalLinkComponent} from '../../../shared/components/external-link/external-link.component';
 import {StationWithParameterGroups} from '../../../shared/models/station-with-parameter-groups';
 import {IconFromConfigPipe} from '../../../shared/pipes/icon-from-config.pipe';
 import {TranslatableStringPipe} from '../../../shared/pipes/translatable-string.pipe';
@@ -11,7 +12,16 @@ import {appFeature} from '../../../state/app/reducers/app.reducer';
 
 @Component({
   selector: 'app-station-info',
-  imports: [IconFromConfigPipe, MatIcon, MatList, MatListItem, TranslatableStringPipe, AsyncPipe, TranslocoDirective],
+  imports: [
+    IconFromConfigPipe,
+    MatIcon,
+    MatList,
+    MatListItem,
+    TranslatableStringPipe,
+    AsyncPipe,
+    TranslocoDirective,
+    ExternalLinkComponent,
+  ],
   templateUrl: './station-info.component.html',
   styleUrl: './station-info.component.scss',
 })

--- a/src/app/shared/components/external-link/external-link.component.html
+++ b/src/app/shared/components/external-link/external-link.component.html
@@ -1,0 +1,1 @@
+<a [href]="href()" rel="noopener noreferrer" target="_blank">{{ text() }}</a>

--- a/src/app/shared/components/external-link/external-link.component.ts
+++ b/src/app/shared/components/external-link/external-link.component.ts
@@ -1,0 +1,12 @@
+import {Component, input} from '@angular/core';
+
+@Component({
+  selector: 'app-external-link',
+  imports: [],
+  templateUrl: './external-link.component.html',
+  styleUrl: './external-link.component.scss',
+})
+export class ExternalLinkComponent {
+  public readonly href = input.required<string>();
+  public readonly text = input<string>();
+}


### PR DESCRIPTION
Introduced a new component which encapsulates the `<a>` element and ensures that links are opened in a new tab.
All existing `<a>` elements are now replaced with this one.