### PR TITLE
Loading spinner #93

### DIFF
--- a/src/app/data-selection-form/components/collection-selection/collection-selection.component.html
+++ b/src/app/data-selection-form/components/collection-selection/collection-selection.component.html
@@ -1,18 +1,15 @@
 @if (currentLanguage$ | async; as currentLanguage) {
   <div class="collection-selection" *transloco="let t">
     <h4>{{ t('form.collection-selection.title') }}</h4>
-    <div class="collection-selection__stations-list">
+    <mat-radio-group class="collection-selection__stations-list" [value]="selectedCollection$ | async">
       @for (station of stationParameterGroups$ | async; track $index) {
         <button matRipple (click)="setSelectedCollection(station.collection)" class="collection-selection__stations-list__station">
-          <mat-radio-button
-            class="collection-selection__stations-list__station__radio-button"
-            [checked]="(selectedCollection$ | async) === station.collection"
-          >
+          <mat-radio-button class="collection-selection__stations-list__station__radio-button" [value]="station.collection">
             {{ station.type | translatableString: currentLanguage }}
           </mat-radio-button>
           <app-station-info [station]="station"></app-station-info>
         </button>
       }
-    </div>
+    </mat-radio-group>
   </div>
 }

--- a/src/app/data-selection-form/components/collection-selection/collection-selection.component.ts
+++ b/src/app/data-selection-form/components/collection-selection/collection-selection.component.ts
@@ -1,7 +1,7 @@
 import {AsyncPipe} from '@angular/common';
 import {Component, inject} from '@angular/core';
 import {MatRipple} from '@angular/material/core';
-import {MatRadioButton} from '@angular/material/radio';
+import {MatRadioButton, MatRadioGroup} from '@angular/material/radio';
 import {TranslocoModule} from '@jsverse/transloco';
 import {Store} from '@ngrx/store';
 import {TranslatableStringPipe} from '../../../shared/pipes/translatable-string.pipe';
@@ -13,7 +13,7 @@ import {StationInfoComponent} from '../station-info/station-info.component';
 
 @Component({
   selector: 'app-collection-selection',
-  imports: [AsyncPipe, TranslatableStringPipe, TranslocoModule, MatRadioButton, StationInfoComponent, MatRipple],
+  imports: [AsyncPipe, TranslatableStringPipe, TranslocoModule, MatRadioButton, MatRadioGroup, StationInfoComponent, MatRipple],
   templateUrl: './collection-selection.component.html',
   styleUrl: './collection-selection.component.scss',
 })

--- a/src/app/data-selection-form/components/interval-selection/interval-selection.component.html
+++ b/src/app/data-selection-form/components/interval-selection/interval-selection.component.html
@@ -1,18 +1,24 @@
-<mat-radio-group
-  class="interval-selection"
-  *transloco="let t"
-  [attr.aria-label]="t('form.interval.aria-label')"
-  [value]="selectedDataInterval$ | async"
-  (change)="setSelectedInterval($event.value)"
->
-  @for (dataInterval of allDataIntervals; track dataInterval.interval) {
-    @let isDataIntervalIncluded = availableDataIntervals$ | async | includes: dataInterval.interval;
-    <div
-      class="interval-selection__selection"
-      [matTooltip]="t('form.selection-not-available')"
-      [matTooltipDisabled]="isDataIntervalIncluded"
-    >
-      <mat-radio-button [value]="dataInterval.interval" [disabled]="!isDataIntervalIncluded">{{ t(dataInterval.label) }}</mat-radio-button>
-    </div>
-  }
-</mat-radio-group>
+@if ((assetLoadingState$ | async) !== 'loaded') {
+  <app-loading-spinner class="loading-indicator"></app-loading-spinner>
+} @else {
+  <mat-radio-group
+    class="interval-selection"
+    *transloco="let t"
+    [attr.aria-label]="t('form.interval.aria-label')"
+    [value]="selectedDataInterval$ | async"
+    (change)="setSelectedInterval($event.value)"
+  >
+    @for (dataInterval of allDataIntervals; track dataInterval.interval) {
+      @let isDataIntervalIncluded = availableDataIntervals$ | async | includes: dataInterval.interval;
+      <div
+        class="interval-selection__selection"
+        [matTooltip]="t('form.selection-not-available')"
+        [matTooltipDisabled]="isDataIntervalIncluded"
+      >
+        <mat-radio-button [value]="dataInterval.interval" [disabled]="!isDataIntervalIncluded">{{
+          t(dataInterval.label)
+        }}</mat-radio-button>
+      </div>
+    }
+  </mat-radio-group>
+}

--- a/src/app/data-selection-form/components/interval-selection/interval-selection.component.scss
+++ b/src/app/data-selection-form/components/interval-selection/interval-selection.component.scss
@@ -6,3 +6,12 @@
     width: fit-content;
   }
 }
+
+.loading-indicator {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 24px;
+  box-sizing: border-box;
+  width: 100%;
+}

--- a/src/app/data-selection-form/components/interval-selection/interval-selection.component.ts
+++ b/src/app/data-selection-form/components/interval-selection/interval-selection.component.ts
@@ -7,14 +7,16 @@ import {marker} from '@jsverse/transloco-keys-manager/marker';
 import {Store} from '@ngrx/store';
 import {dataIntervals} from '../../../shared/models/interval';
 import {IncludesPipe} from '../../../shared/pipes/includes.pipe';
+import {assetFeature} from '../../../state/assets/reducers/asset.reducer';
 import {selectAvailableDataIntervals} from '../../../state/assets/selectors/asset.selectors';
 import {formActions} from '../../../state/form/actions/form.actions';
 import {formFeature} from '../../../state/form/reducers/form.reducer';
+import {LoadingSpinnerComponent} from '../loading-spinner/loading-spinner.component';
 import type {DataInterval} from '../../../shared/models/interval';
 
 @Component({
   selector: 'app-interval-selection',
-  imports: [TranslocoModule, AsyncPipe, IncludesPipe, MatRadioModule, MatTooltip],
+  imports: [TranslocoModule, AsyncPipe, IncludesPipe, MatRadioModule, MatTooltip, LoadingSpinnerComponent],
   templateUrl: './interval-selection.component.html',
   styleUrl: './interval-selection.component.scss',
 })
@@ -36,6 +38,7 @@ export class IntervalSelectionComponent {
     label: this.dataIntervalLabelMapping[interval],
   }));
   protected readonly availableDataIntervals$ = this.store.select(selectAvailableDataIntervals);
+  protected readonly assetLoadingState$ = this.store.select(assetFeature.selectLoadingState);
 
   protected setSelectedInterval(interval: DataInterval): void {
     this.store.dispatch(formActions.setSelectedDataInterval({dataInterval: interval}));

--- a/src/app/data-selection-form/components/loading-spinner/loading-spinner.component.html
+++ b/src/app/data-selection-form/components/loading-spinner/loading-spinner.component.html
@@ -1,0 +1,1 @@
+<mat-spinner></mat-spinner>

--- a/src/app/data-selection-form/components/loading-spinner/loading-spinner.component.ts
+++ b/src/app/data-selection-form/components/loading-spinner/loading-spinner.component.ts
@@ -1,0 +1,10 @@
+import {Component} from '@angular/core';
+import {MatProgressSpinnerModule} from '@angular/material/progress-spinner';
+
+@Component({
+  selector: 'app-loading-spinner',
+  imports: [MatProgressSpinnerModule],
+  templateUrl: './loading-spinner.component.html',
+  styleUrl: './loading-spinner.component.scss',
+})
+export class LoadingSpinnerComponent {}

--- a/src/app/data-selection-form/constants/data-selection-form.constant.ts
+++ b/src/app/data-selection-form/constants/data-selection-form.constant.ts
@@ -1,3 +1,0 @@
-export const dataSelectionFormConstants = {
-  INITIAL_STEP_DEBOUNCE_TIME_IN_MS: 100,
-} as const;

--- a/src/app/data-selection-form/data-selection-form.component.ts
+++ b/src/app/data-selection-form/data-selection-form.component.ts
@@ -1,21 +1,24 @@
+import {Overlay, OverlayRef} from '@angular/cdk/overlay';
+import {ComponentPortal} from '@angular/cdk/portal';
 import {AsyncPipe} from '@angular/common';
 import {AfterViewInit, Component, inject, OnDestroy, ViewChild} from '@angular/core';
 import {MatButton} from '@angular/material/button';
 import {MatIcon} from '@angular/material/icon';
+import {MatProgressSpinnerModule} from '@angular/material/progress-spinner';
 import {MatStepper, MatStepperModule} from '@angular/material/stepper';
 import {TranslocoModule} from '@jsverse/transloco';
 import {Store} from '@ngrx/store';
-import {debounceTime, Subscription, tap} from 'rxjs';
+import {filter, Subscription, switchMap, tap} from 'rxjs';
 import {formFeature} from '../state/form/reducers/form.reducer';
 import {selectSelectedStationForCollection} from '../state/form/selectors/form.selector';
 import {DownloadAssetComponent} from './components/download-asset/download-asset.component';
 import {IntervalSelectionComponent} from './components/interval-selection/interval-selection.component';
+import {LoadingSpinnerComponent} from './components/loading-spinner/loading-spinner.component';
 import {MeasurementDataTypeSelectionComponent} from './components/measurement-data-type-selection/measurement-data-type-selection.component';
 import {SelectionReviewComponent} from './components/selection-review/selection-review.component';
 import {StationSelectionStepComponent} from './components/station-selection-step/station-selection-step.component';
 import {StepLabelComponent} from './components/step-label/step-label.component';
 import {TimeRangeSelectionComponent} from './components/time-range-selection/time-range-selection.component';
-import {dataSelectionFormConstants} from './constants/data-selection-form.constant';
 import type {FormStep} from '../shared/constants/form-step.constant';
 
 @Component({
@@ -33,12 +36,16 @@ import type {FormStep} from '../shared/constants/form-step.constant';
     MeasurementDataTypeSelectionComponent,
     StepLabelComponent,
     MatIcon,
+    MatProgressSpinnerModule,
   ],
   templateUrl: './data-selection-form.component.html',
   styleUrl: './data-selection-form.component.scss',
 })
 export class DataSelectionFormComponent implements AfterViewInit, OnDestroy {
   private readonly store = inject(Store);
+  private readonly overlay = inject(Overlay);
+
+  private overlayRef: OverlayRef | null = null;
 
   @ViewChild(MatStepper) private readonly stepper: MatStepper | undefined;
   protected readonly selectedStationForCollection$ = this.store.select(selectSelectedStationForCollection);
@@ -48,6 +55,8 @@ export class DataSelectionFormComponent implements AfterViewInit, OnDestroy {
   private readonly subscriptions: Subscription = new Subscription();
 
   public ngAfterViewInit(): void {
+    this.showLoadingIndicator();
+
     this.subscriptions.add(
       this.store
         .select(formFeature.selectSelectedMeasurementDataType)
@@ -57,11 +66,14 @@ export class DataSelectionFormComponent implements AfterViewInit, OnDestroy {
 
     this.subscriptions.add(
       this.store
-        .select(formFeature.selectInitialStep)
+        .select(formFeature.selectIsDataIntervalAndTimeRangeInitialized)
         .pipe(
-          // wait for all collections/assets to be loaded
-          debounceTime(dataSelectionFormConstants.INITIAL_STEP_DEBOUNCE_TIME_IN_MS),
-          tap((initialStep) => this.setSelectedStep(initialStep)),
+          filter((isInitialized) => isInitialized),
+          switchMap(() => this.store.select(formFeature.selectInitialStep)),
+          tap((initialStep) => {
+            this.setSelectedStep(initialStep);
+            this.hideLoadingIndicator();
+          }),
         )
         .subscribe(),
     );
@@ -74,7 +86,27 @@ export class DataSelectionFormComponent implements AfterViewInit, OnDestroy {
   private setSelectedStep(step: FormStep): void {
     const stepper = this.stepper;
     if (stepper) {
-      stepper.selectedIndex = step;
+      setTimeout(() => (stepper.selectedIndex = step));
+    }
+  }
+
+  private showLoadingIndicator(): void {
+    if (!this.overlayRef) {
+      this.overlayRef = this.overlay.create({
+        hasBackdrop: true,
+        backdropClass: 'cdk-overlay-dark-backdrop',
+        positionStrategy: this.overlay.position().global().centerHorizontally().centerVertically(),
+      });
+
+      this.overlayRef.attach(new ComponentPortal(LoadingSpinnerComponent));
+    }
+  }
+
+  private hideLoadingIndicator(): void {
+    if (this.overlayRef) {
+      this.overlayRef.detach();
+      this.overlayRef.dispose();
+      this.overlayRef = null;
     }
   }
 }

--- a/src/app/data-selection-form/data-selection-form.component.ts
+++ b/src/app/data-selection-form/data-selection-form.component.ts
@@ -80,6 +80,7 @@ export class DataSelectionFormComponent implements AfterViewInit, OnDestroy {
   }
 
   public ngOnDestroy(): void {
+    this.hideLoadingIndicator();
     this.subscriptions.unsubscribe();
   }
 

--- a/src/app/state/form/effects/form.effects.spec.ts
+++ b/src/app/state/form/effects/form.effects.spec.ts
@@ -189,6 +189,7 @@ describe('FormEffects', () => {
           fail(`Expected no action to be dispatched, but got: ${action.type}`);
         },
         complete: () => {
+          expect().nothing();
           done();
         },
       });

--- a/src/app/state/form/effects/form.effects.spec.ts
+++ b/src/app/state/form/effects/form.effects.spec.ts
@@ -265,5 +265,32 @@ describe('FormEffects', () => {
         done();
       });
     });
+
+    it('should dispatch initializeSelectedDataIntervalAndTimeRange with values null if stationId or collectionId is null', (done) => {
+      actions$ = of(
+        appActions.initializeApp({
+          parameter: {
+            dataInterval: 'monthly',
+            timeRange: 'historical',
+            historicalDateRange: {start: startDate, end: endDate},
+          } as AppUrlParameter,
+        }),
+      );
+      store.overrideSelector(formFeature.selectFormState, {
+        isParameterGroupStationAndCollectionInitialized: true,
+        selectedStationId: 'not-null',
+        selectedCollection: null,
+      } as FormState);
+      initializeSelectedDataIntervalAndTimeRange(actions$, store).subscribe((action) => {
+        expect(action).toEqual(
+          formActions.initializeSelectedDataIntervalAndTimeRange({
+            dataInterval: null,
+            timeRange: null,
+            historicalDateRange: null,
+          }),
+        );
+        done();
+      });
+    });
   });
 });

--- a/src/app/state/form/reducers/form.reducer.spec.ts
+++ b/src/app/state/form/reducers/form.reducer.spec.ts
@@ -16,6 +16,7 @@ describe('Form Reducer', () => {
       selectedCollection: 'collection',
       selectedHistoricalDateRange: {start: new Date(), end: new Date()},
       isParameterGroupStationAndCollectionInitialized: false,
+      isDataIntervalAndTimeRangeInitialized: false,
       initialStep: formStepConstants.STATION_SELECTION,
     };
   });
@@ -95,6 +96,7 @@ describe('Form Reducer', () => {
       selectedTimeRange: 'now',
       selectedHistoricalDateRange: {start: new Date('2025-01-01T00:00Z'), end: new Date('2025-01-01T00:00Z')},
       initialStep: formStepConstants.SELECTION_REVIEW,
+      isDataIntervalAndTimeRangeInitialized: true,
     });
   });
 

--- a/src/app/state/form/reducers/form.reducer.ts
+++ b/src/app/state/form/reducers/form.reducer.ts
@@ -15,6 +15,7 @@ export const initialState: FormState = {
   selectedCollection: null,
   selectedHistoricalDateRange: null,
   isParameterGroupStationAndCollectionInitialized: false,
+  isDataIntervalAndTimeRangeInitialized: false,
   initialStep: formStepConstants.STATION_SELECTION,
 };
 
@@ -49,6 +50,7 @@ export const formFeature = createFeature({
         selectedDataInterval: dataInterval,
         selectedTimeRange: timeRange,
         selectedHistoricalDateRange: historicalDateRange,
+        isDataIntervalAndTimeRangeInitialized: true,
         initialStep,
       };
     }),

--- a/src/app/state/form/states/form.state.ts
+++ b/src/app/state/form/states/form.state.ts
@@ -13,5 +13,6 @@ export interface FormState {
   selectedCollection: string | null;
   selectedHistoricalDateRange: DateRange | null;
   isParameterGroupStationAndCollectionInitialized: boolean;
+  isDataIntervalAndTimeRangeInitialized: boolean;
   initialStep: FormStep;
 }


### PR DESCRIPTION
This PR adds a spinner to communicate to the user that data is being loaded.

This indicator is used at the startup of the application where the
metadata-csvs and, if applicable, the station assets need to be loaded
from STAC. Once the initial data is loaded and the application is ready
to take interactions from the user, the indicator is removed.

The interval selection step can only be done, if the available assets
have been loaded for the selected station and collection. These indicate
which selection options are available to the user. The fetch happens
immediately after a collection is selected. But depending on the network
speed there might be a case where the user clicks the next button but
the data is not yet available. In this case it should be communicated to
the user using a loading indicator in the step, that the selection is
not yet ready. Once the data is loaded the indicator is replaced with
the selection.