### PR TITLE
Fix map in productive build MeteoSwiss/opendata-explorer#137

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -16,6 +16,7 @@ components use Angular Material, and translations run through Transloco.
 - `npm run format` / `npm run format:check` — Prettier over `./src`
 - `npm run i18n:extract` then `npm run i18n:find` — regenerate/verify Transloco keys in `public/i18n`; `i18n:find` also runs in the pre-commit hook and fails the commit silently-ish (only prints a warning, doesn't block) if keys are missing/unused
 - `npm run generate-stac-api` — regenerates `src/app/stac/generated/stac-api.generated.ts` from the MeteoSwiss STAC OpenAPI spec; never hand-edit generated STAC types
+- `npm run build` — production build; output goes to `dist/browser/` (not `dist/<project-name>/browser/` — `outputPath` in `angular.json` is a plain string `"dist"`, and `@angular/build:application` writes straight into `dist/browser/` with no project-name segment). To verify the production build actually works locally (bypassing `ng serve`'s Vite dev-server, which can mask asset-resolution bugs that only reproduce in a real build): `npx http-server dist\browser -p 8080`, then open `http://localhost:8080`.
 - Node version is pinned via `.nvmrc`
 
 ## Git hooks (Husky) — non-blocking but noisy

--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ yarn-error.log
 testem.log
 /typings
 /.opencode
+/.playwright-cli
 
 # System files
 .DS_Store

--- a/angular.json
+++ b/angular.json
@@ -29,6 +29,16 @@
               {
                 "glob": "**/*",
                 "input": "public"
+              },
+              {
+                "glob": "maplibre-gl-worker.mjs",
+                "input": "node_modules/maplibre-gl/dist",
+                "output": "assets/maplibre-gl"
+              },
+              {
+                "glob": "maplibre-gl-shared.mjs",
+                "input": "node_modules/maplibre-gl/dist",
+                "output": "assets/maplibre-gl"
               }
             ],
             "styles": [
@@ -90,6 +100,16 @@
               {
                 "glob": "**/*",
                 "input": "public"
+              },
+              {
+                "glob": "maplibre-gl-worker.mjs",
+                "input": "node_modules/maplibre-gl/dist",
+                "output": "assets/maplibre-gl"
+              },
+              {
+                "glob": "maplibre-gl-shared.mjs",
+                "input": "node_modules/maplibre-gl/dist",
+                "output": "assets/maplibre-gl"
               }
             ],
             "styles": [

--- a/src/app/map/services/map.service.ts
+++ b/src/app/map/services/map.service.ts
@@ -22,9 +22,11 @@ import {mapActions} from '../../state/map/actions/map.action';
 import {MapViewport} from '../models/map-viewport';
 
 // maplibre-gl v6 no longer auto-detects its worker's URL under bundlers, since
-// import.meta.url doesn't reliably resolve inside a bundler's module graph.
+// import.meta.url doesn't reliably resolve inside a bundler's module graph. This
+// project's esbuild-based build needs the worker copied to `assets/maplibre-gl`
+// (see angular.json) and resolved via `document.baseURI` instead of import.meta.url.
 // See: https://github.com/maplibre/maplibre-gl-js/blob/v6.0.0/docs/guides/v5-to-v6-migration-guide.md
-setWorkerUrl(new URL('maplibre-gl/dist/maplibre-gl-worker.mjs', import.meta.url).toString());
+setWorkerUrl(new URL('assets/maplibre-gl/maplibre-gl-worker.mjs', document.baseURI).toString());
 
 @Injectable({
   providedIn: 'root',


### PR DESCRIPTION
Serve MapLibre worker from a copied asset path MeteoSwiss/opendata-explorer#137

MapLibre v6 stopped auto-detecting its worker URL under bundlers, and
the previous import.meta.url reference resolved only under ng serve,
where Vite serves node_modules on demand. The production esbuild output
never contained the worker, so the map stayed blank. The worker and its
required maplibre-gl-shared.mjs sibling are now emitted as assets and
resolved against document.baseURI, which keeps working under the
--base-href used for the GitHub Pages deployment.